### PR TITLE
chore: remove "shamefully-hoist" from .npmrc configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 registry="https://registry.npmjs.org/"
-shamefully-hoist=true
 strict-peer-dependencies=false
 side-effects-cache=false


### PR DESCRIPTION
#5 
You can delete the node_modules directory and reinstall it, then you will be able to see the error message.