### PR TITLE
chore: release v4.0.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactuses/core",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "license": "Unlicense",
   "homepage": "https://www.reactuse.com/",
   "repository": {

--- a/packages/core/scripts/rollup.config.ts
+++ b/packages/core/scripts/rollup.config.ts
@@ -23,13 +23,13 @@ output.push({
   format: "cjs",
 });
 configs.push({
-  external: ["react", "lodash-es", "screenfull"],
+  external: ["react"],
   input,
   output,
   plugins: [esbuildPlugin, json(), resolve({ extensions: [".ts"] }), common()],
 });
 configs.push({
-  external: ["react", "lodash-es", "screenfull"],
+  external: ["react"],
   input,
   output: {
     file: path.resolve(__dirname, "../dist/index.d.ts"),


### PR DESCRIPTION
esm packages can't external