### PR TITLE
usePermission: Do not fail on Safari 15

### DIFF
--- a/packages/core/hooks/usePermission/index.ts
+++ b/packages/core/hooks/usePermission/index.ts
@@ -47,8 +47,7 @@ export default function usePermission(
       setState(() => permissionStatus?.state ?? "");
     };
 
-    navigator.permissions
-      .query(desc)
+    navigator.permissions?.query(desc)
       .then((status) => {
         permissionStatus = status;
         on(permissionStatus, "change", onChange);


### PR DESCRIPTION
`navigator.permissions.query` is not a function on Safari 15, so this fixes a thrown error when that scenario occurs