### PR TITLE
fix: link NPM badges to package page on npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 </p>
 
 <p align="center">
-  <img alt="NPM Version" src="https://img.shields.io/npm/v/@reactuses/core?style=for-the-badge&labelColor=24292e">
-  <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@reactuses/core?color=50a36f&label=&style=for-the-badge&labelColor=24292e">
+  <a href="https://www.npmjs.com/package/@reactuses/core"><img alt="NPM Version" src="https://img.shields.io/npm/v/@reactuses/core?style=for-the-badge&labelColor=24292e"></a>
+  <a href="https://www.npmjs.com/package/@reactuses/core"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@reactuses/core?color=50a36f&label=&style=for-the-badge&labelColor=24292e"></a>
   <img alt="UnLicense" src="https://img.shields.io/npm/l/@reactuses/core?style=for-the-badge&labelColor=24292e">
   <img alt="Tree Shaking Friendly" src="https://img.shields.io/badge/Tree%20Shaking-Friendly-brightgreen?style=for-the-badge&labelColor=24292e">
   <img alt="TypeScript Support" src="https://img.shields.io/badge/TypeScript-Support-blue?style=for-the-badge&labelColor=24292e">


### PR DESCRIPTION
## Summary

- Wrap the NPM Version and NPM Downloads badges in `<a>` tags linking to https://www.npmjs.com/package/@reactuses/core
- Previously these badges were plain `<img>` elements with no hyperlink, so clicking them did nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)