### PR TITLE
feat(core): add useMicrophone hook

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ import { useLongPress } from './useLongPress'
 import { useMeasure } from './useMeasure'
 import { useMediaDevices } from './useMediaDevices'
 import { useMediaQuery } from './useMediaQuery'
+import { useMicrophone } from './useMicrophone'
 import { useMount } from './useMount'
 import { useMountedState } from './useMountedState'
 import { useMouse } from './useMouse'
@@ -152,6 +153,7 @@ export {
   useObjectUrl,
   useIdle,
   useMediaDevices,
+  useMicrophone,
   useTextDirection,
   useMouse,
   useFps,
@@ -272,6 +274,7 @@ export * from './useLongPress/interface'
 export * from './useMeasure/interface'
 export * from './useMediaDevices/interface'
 export * from './useMediaQuery/interface'
+export * from './useMicrophone/interface'
 export * from './useMount/interface'
 export * from './useMountedState/interface'
 export * from './useMouse/interface'

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -368,4 +368,27 @@ describe('useMicrophone', () => {
       expect(urls.revoked).toContain('blob:test/1')
     })
   })
+
+  describe('pause / resume recording', () => {
+    it('toggles isPaused and forwards to MediaRecorder.pause/resume', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+      act(() => { result.current.startRecording() })
+
+      const recorder = result.current.recorder as unknown as FakeMediaRecorder
+      act(() => { result.current.pauseRecording() })
+      expect(recorder.pause).toHaveBeenCalledTimes(1)
+      expect(result.current.isPaused).toBe(true)
+
+      act(() => { result.current.resumeRecording() })
+      expect(recorder.resume).toHaveBeenCalledTimes(1)
+      expect(result.current.isPaused).toBe(false)
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -314,6 +314,18 @@ describe('useMicrophone', () => {
       expect(result.current.isRecording).toBe(false)
     })
 
+    it('sets an error when startRecording is called before start', () => {
+      installMediaRecorderMock()
+      installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      act(() => { result.current.startRecording() })
+
+      expect(result.current.isRecording).toBe(false)
+      expect(result.current.error?.message).toMatch(/call start\(\) before startRecording\(\)/)
+    })
+
     it('clears the recorder reference after stopRecording', async () => {
       patchRaf()
       installAudioContextMock()

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -442,6 +442,39 @@ describe('useMicrophone', () => {
       expect(result.current.isActive).toBe(false)
       expect(result.current.error?.message).toMatch(/disconnect/i)
     })
+
+    it('attaches the ended listener to tracks acquired via deviceId change', async () => {
+      patchRaf()
+      installAudioContextMock()
+      const oldTrack = makeMockTrack()
+      const newTrack = makeMockTrack()
+      const oldStream = makeMockStream([oldTrack])
+      const newStream = makeMockStream([newTrack])
+      installMediaDevicesMock(jest
+        .fn()
+        .mockResolvedValueOnce(oldStream)
+        .mockResolvedValueOnce(newStream))
+
+      const { result, rerender } = renderHook(
+        ({ deviceId }: { deviceId?: string }) => useMicrophone({ deviceId }),
+        { initialProps: { deviceId: 'mic-a' } },
+      )
+
+      await act(async () => { await result.current.start() })
+
+      await act(async () => {
+        rerender({ deviceId: 'mic-b' })
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      const endedCall = newTrack.addEventListener.mock.calls.find(c => c[0] === 'ended')
+      expect(endedCall).toBeDefined()
+
+      act(() => { endedCall![1](new Event('ended')) })
+      expect(result.current.isActive).toBe(false)
+      expect(result.current.error?.message).toMatch(/disconnect/i)
+    })
   })
 
   describe('stop while recording', () => {

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -300,6 +300,22 @@ describe('useMicrophone', () => {
       expect(urlSpy.created).toEqual(['blob:test/1'])
       expect(result.current.isRecording).toBe(false)
     })
+
+    it('clears the recorder reference after stopRecording', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+      act(() => { result.current.startRecording() })
+      expect(result.current.recorder).not.toBeNull()
+
+      await act(async () => { await result.current.stopRecording() })
+      expect(result.current.recorder).toBeNull()
+    })
   })
 
   describe('mime-type selection', () => {

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -420,4 +420,27 @@ describe('useMicrophone', () => {
       expect(getUserMedia).not.toHaveBeenCalled()
     })
   })
+
+  describe('track ended', () => {
+    it('flips isActive=false and sets error when the audio track ends', async () => {
+      patchRaf()
+      installAudioContextMock()
+      const track = makeMockTrack()
+      const stream = makeMockStream([track])
+      installMediaDevicesMock(jest.fn().mockResolvedValue(stream))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+
+      // Capture the ended listener registered by the hook
+      const endedCall = track.addEventListener.mock.calls.find(c => c[0] === 'ended')
+      expect(endedCall).toBeDefined()
+      const endedHandler = endedCall![1]
+
+      act(() => { endedHandler(new Event('ended')) })
+
+      expect(result.current.isActive).toBe(false)
+      expect(result.current.error?.message).toMatch(/disconnect/i)
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -81,6 +81,45 @@ function patchRaf() {
   }
 }
 
+class FakeMediaRecorder {
+  static isTypeSupported = jest.fn((t: string) => t === 'audio/webm;codecs=opus')
+  state: 'inactive' | 'recording' | 'paused' = 'inactive'
+  mimeType: string
+  ondataavailable: ((e: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  constructor(public stream: any, opts?: { mimeType?: string }) {
+    this.mimeType = opts?.mimeType || ''
+  }
+
+  start = jest.fn(() => { this.state = 'recording' })
+  stop = jest.fn(() => {
+    this.state = 'inactive'
+    this.ondataavailable?.({ data: new Blob(['chunk'], { type: this.mimeType || 'audio/webm' }) })
+    this.onstop?.()
+  })
+
+  pause = jest.fn(() => { this.state = 'paused' })
+  resume = jest.fn(() => { this.state = 'recording' })
+}
+
+function installMediaRecorderMock() {
+  ;(global as any).MediaRecorder = FakeMediaRecorder
+  FakeMediaRecorder.isTypeSupported = jest.fn((t: string) => t === 'audio/webm;codecs=opus')
+}
+
+function installUrlMock() {
+  let counter = 0
+  const created: string[] = []
+  const revoked: string[] = []
+  ;(global as any).URL.createObjectURL = jest.fn(() => {
+    const u = `blob:test/${++counter}`
+    created.push(u)
+    return u
+  })
+  ;(global as any).URL.revokeObjectURL = jest.fn((u: string) => { revoked.push(u) })
+  return { created, revoked }
+}
+
 describe('useMicrophone', () => {
   describe('capability detection', () => {
     const originalMediaDevices = (global.navigator as any).mediaDevices
@@ -230,6 +269,36 @@ describe('useMicrophone', () => {
       const secondCallConstraints = getUserMedia.mock.calls[1][0].audio
       expect(secondCallConstraints.deviceId).toEqual({ exact: 'mic-b' })
       expect(result.current.stream).toBe(newStream)
+    })
+  })
+
+  describe('recording', () => {
+    it('startRecording + stopRecording yields a Blob and a hook-managed audioUrl', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      const urlSpy = installUrlMock()
+      const getUserMedia = jest.fn().mockResolvedValue(makeMockStream())
+      installMediaDevicesMock(getUserMedia)
+
+      const { result } = renderHook(() => useMicrophone())
+
+      await act(async () => { await result.current.start() })
+
+      act(() => { result.current.startRecording() })
+      expect(result.current.isRecording).toBe(true)
+      expect(result.current.mimeType).toBe('audio/webm;codecs=opus')
+
+      let returned: Blob | null = null
+      await act(async () => {
+        returned = await result.current.stopRecording()
+      })
+
+      expect(returned).toBeInstanceOf(Blob)
+      expect(result.current.blob).toBeInstanceOf(Blob)
+      expect(result.current.audioUrl).toBe('blob:test/1')
+      expect(urlSpy.created).toEqual(['blob:test/1'])
+      expect(result.current.isRecording).toBe(false)
     })
   })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -194,4 +194,42 @@ describe('useMicrophone', () => {
       expect(result.current.level).toBe(0)
     })
   })
+
+  describe('deviceId reactivity', () => {
+    it('re-acquires the stream when deviceId changes while active', async () => {
+      patchRaf()
+      installAudioContextMock()
+
+      const oldTrack = makeMockTrack()
+      const newTrack = makeMockTrack()
+      const oldStream = makeMockStream([oldTrack])
+      const newStream = makeMockStream([newTrack])
+      const getUserMedia = jest
+        .fn()
+        .mockResolvedValueOnce(oldStream)
+        .mockResolvedValueOnce(newStream)
+      installMediaDevicesMock(getUserMedia)
+
+      const { result, rerender } = renderHook(
+        ({ deviceId }: { deviceId?: string }) => useMicrophone({ deviceId }),
+        { initialProps: { deviceId: 'mic-a' } },
+      )
+
+      await act(async () => { await result.current.start() })
+      expect(result.current.stream).toBe(oldStream)
+
+      await act(async () => {
+        rerender({ deviceId: 'mic-b' })
+        // Let the effect flush
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(oldTrack.stop).toHaveBeenCalled()
+      expect(getUserMedia).toHaveBeenCalledTimes(2)
+      const secondCallConstraints = getUserMedia.mock.calls[1][0].audio
+      expect(secondCallConstraints.deviceId).toEqual({ exact: 'mic-b' })
+      expect(result.current.stream).toBe(newStream)
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -25,6 +25,62 @@ function installMediaDevicesMock(getUserMedia: jest.Mock) {
   })
 }
 
+class FakeAnalyser {
+  fftSize = 2048
+  smoothingTimeConstant = 0.8
+  frequencyBinCount = 1024
+  connect = jest.fn()
+  disconnect = jest.fn()
+  // Test harness fills this; the hook will read it via getByteTimeDomainData
+  nextData: number[] = []
+  getByteTimeDomainData(out: Uint8Array) {
+    for (let i = 0; i < out.length; i++) out[i] = this.nextData[i] ?? 128
+  }
+}
+
+class FakeSourceNode {
+  connect = jest.fn()
+  disconnect = jest.fn()
+}
+
+class FakeAudioContext {
+  state = 'running'
+  close = jest.fn(async () => { this.state = 'closed' })
+  createMediaStreamSource = jest.fn(() => new FakeSourceNode())
+  createAnalyser = jest.fn(() => {
+    this.lastAnalyser = new FakeAnalyser()
+    return this.lastAnalyser
+  })
+  lastAnalyser: FakeAnalyser | null = null
+}
+
+function installAudioContextMock() {
+  const ctor = jest.fn(() => new FakeAudioContext())
+  ;(global as any).AudioContext = ctor
+  ;(global as any).webkitAudioContext = ctor
+  return ctor
+}
+
+function patchRaf() {
+  let callbacks: Array<(t: number) => void> = []
+  let now = 0
+  ;(global as any).requestAnimationFrame = (cb: (t: number) => void) => {
+    callbacks.push(cb)
+    return callbacks.length
+  }
+  ;(global as any).cancelAnimationFrame = jest.fn()
+  ;(global as any).performance = (global as any).performance || { now: () => now }
+  ;(global as any).performance.now = () => now
+  return {
+    flush(advanceMs: number) {
+      now += advanceMs
+      const cbs = callbacks
+      callbacks = []
+      cbs.forEach(cb => cb(now))
+    },
+  }
+}
+
 describe('useMicrophone', () => {
   describe('capability detection', () => {
     const originalMediaDevices = (global.navigator as any).mediaDevices
@@ -101,6 +157,41 @@ describe('useMicrophone', () => {
       expect(result.current.isActive).toBe(false)
       expect(result.current.stream).toBeNull()
       expect(result.current.error).toBe(denial)
+    })
+  })
+
+  describe('level meter', () => {
+    it('emits level via state at the configured throttle interval', async () => {
+      const raf = patchRaf()
+      installAudioContextMock()
+      const getUserMedia = jest.fn().mockResolvedValue(makeMockStream())
+      installMediaDevicesMock(getUserMedia)
+
+      const { result } = renderHook(() => useMicrophone({ levelInterval: 100 }))
+
+      await act(async () => {
+        await result.current.start()
+      })
+
+      expect(result.current.analyser).toBeTruthy()
+
+      // Feed loud audio: 255 = peak deviation from 128 midpoint, so RMS=1.0
+      const analyser = result.current.analyser as unknown as FakeAnalyser
+      analyser.nextData = new Array(analyser.frequencyBinCount).fill(255)
+
+      // First frame at t=0 should emit (lastEmit is initialized so the first tick fires)
+      act(() => { raf.flush(0) })
+      expect(result.current.level).toBeGreaterThan(0)
+      const firstLevel = result.current.level
+
+      // A frame at t=50ms should NOT emit (under the 100ms throttle)
+      analyser.nextData = new Array(analyser.frequencyBinCount).fill(128) // silence
+      act(() => { raf.flush(50) })
+      expect(result.current.level).toBe(firstLevel)
+
+      // A frame at t=150ms should emit (>=100ms since last)
+      act(() => { raf.flush(100) })
+      expect(result.current.level).toBe(0)
     })
   })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -1,5 +1,29 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import { useMicrophone } from '.'
+
+function makeMockTrack() {
+  return {
+    kind: 'audio',
+    stop: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  }
+}
+
+function makeMockStream(tracks = [makeMockTrack()]) {
+  return {
+    getTracks: () => tracks,
+    getAudioTracks: () => tracks.filter(t => t.kind === 'audio'),
+    _tracks: tracks,
+  }
+}
+
+function installMediaDevicesMock(getUserMedia: jest.Mock) {
+  Object.defineProperty(global.navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  })
+}
 
 describe('useMicrophone', () => {
   describe('capability detection', () => {
@@ -30,6 +54,35 @@ describe('useMicrophone', () => {
 
       const { result } = renderHook(() => useMicrophone())
       expect(result.current.isSupported).toBe(true)
+    })
+  })
+
+  describe('start/stop lifecycle', () => {
+    it('start() acquires a stream and flips isActive; stop() releases it', async () => {
+      const track = makeMockTrack()
+      const stream = makeMockStream([track])
+      const getUserMedia = jest.fn().mockResolvedValue(stream)
+      installMediaDevicesMock(getUserMedia)
+
+      const { result } = renderHook(() => useMicrophone())
+
+      await act(async () => {
+        await result.current.start()
+      })
+
+      expect(getUserMedia).toHaveBeenCalledTimes(1)
+      const constraintsArg = getUserMedia.mock.calls[0][0]
+      expect(constraintsArg).toHaveProperty('audio')
+      expect(result.current.isActive).toBe(true)
+      expect(result.current.stream).toBe(stream)
+
+      act(() => {
+        result.current.stop()
+      })
+
+      expect(track.stop).toHaveBeenCalledTimes(1)
+      expect(result.current.isActive).toBe(false)
+      expect(result.current.stream).toBeNull()
     })
   })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -301,4 +301,35 @@ describe('useMicrophone', () => {
       expect(result.current.isRecording).toBe(false)
     })
   })
+
+  describe('mime-type selection', () => {
+    it('falls back to audio/mp4 when webm is unsupported', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      // Override isTypeSupported: webm unsupported, mp4 supported
+      ;(FakeMediaRecorder as any).isTypeSupported = jest.fn((t: string) => t === 'audio/mp4')
+      installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+      act(() => { result.current.startRecording() })
+      expect(result.current.mimeType).toBe('audio/mp4')
+    })
+
+    it('honors a supported preferred mimeType option', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      ;(FakeMediaRecorder as any).isTypeSupported = jest.fn(() => true)
+      installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone({ mimeType: 'audio/ogg;codecs=opus' }))
+      await act(async () => { await result.current.start() })
+      act(() => { result.current.startRecording() })
+      expect(result.current.mimeType).toBe('audio/ogg;codecs=opus')
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -332,4 +332,40 @@ describe('useMicrophone', () => {
       expect(result.current.mimeType).toBe('audio/ogg;codecs=opus')
     })
   })
+
+  describe('object URL lifecycle', () => {
+    it('revokes the previous audioUrl when a new recording starts', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      const urls = installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+
+      act(() => { result.current.startRecording() })
+      await act(async () => { await result.current.stopRecording() })
+      expect(result.current.audioUrl).toBe('blob:test/1')
+
+      act(() => { result.current.startRecording() })
+      expect(urls.revoked).toContain('blob:test/1')
+    })
+
+    it('revokes the audioUrl on unmount', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      const urls = installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result, unmount } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+      act(() => { result.current.startRecording() })
+      await act(async () => { await result.current.stopRecording() })
+
+      unmount()
+      expect(urls.revoked).toContain('blob:test/1')
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -391,4 +391,33 @@ describe('useMicrophone', () => {
       expect(result.current.isPaused).toBe(false)
     })
   })
+
+  describe('autoStart', () => {
+    it('opens the mic on mount when autoStart=true', async () => {
+      patchRaf()
+      installAudioContextMock()
+      const getUserMedia = jest.fn().mockResolvedValue(makeMockStream())
+      installMediaDevicesMock(getUserMedia)
+
+      let r: any
+      await act(async () => {
+        r = renderHook(() => useMicrophone({ autoStart: true }))
+        // Flush microtasks for the awaited getUserMedia
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(getUserMedia).toHaveBeenCalledTimes(1)
+      expect(r.result.current.isActive).toBe(true)
+    })
+
+    it('does not open the mic on mount by default', () => {
+      patchRaf()
+      installAudioContextMock()
+      const getUserMedia = jest.fn().mockResolvedValue(makeMockStream())
+      installMediaDevicesMock(getUserMedia)
+
+      renderHook(() => useMicrophone())
+      expect(getUserMedia).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -85,4 +85,22 @@ describe('useMicrophone', () => {
       expect(result.current.stream).toBeNull()
     })
   })
+
+  describe('permission denial', () => {
+    it('sets error and stays inactive when getUserMedia rejects', async () => {
+      const denial = Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' })
+      const getUserMedia = jest.fn().mockRejectedValue(denial)
+      installMediaDevicesMock(getUserMedia)
+
+      const { result } = renderHook(() => useMicrophone())
+
+      await act(async () => {
+        await expect(result.current.start()).rejects.toBe(denial)
+      })
+
+      expect(result.current.isActive).toBe(false)
+      expect(result.current.stream).toBeNull()
+      expect(result.current.error).toBe(denial)
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react'
+import { useMicrophone } from '.'
+
+describe('useMicrophone', () => {
+  describe('capability detection', () => {
+    const originalMediaDevices = (global.navigator as any).mediaDevices
+
+    afterEach(() => {
+      Object.defineProperty(global.navigator, 'mediaDevices', {
+        value: originalMediaDevices,
+        configurable: true,
+      })
+    })
+
+    it('reports isSupported=false when mediaDevices is undefined', () => {
+      Object.defineProperty(global.navigator, 'mediaDevices', {
+        value: undefined,
+        configurable: true,
+      })
+
+      const { result } = renderHook(() => useMicrophone())
+      expect(result.current.isSupported).toBe(false)
+    })
+
+    it('reports isSupported=true when getUserMedia exists', () => {
+      Object.defineProperty(global.navigator, 'mediaDevices', {
+        value: { getUserMedia: jest.fn() },
+        configurable: true,
+      })
+
+      const { result } = renderHook(() => useMicrophone())
+      expect(result.current.isSupported).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -443,4 +443,27 @@ describe('useMicrophone', () => {
       expect(result.current.error?.message).toMatch(/disconnect/i)
     })
   })
+
+  describe('stop while recording', () => {
+    it('stop() halts an in-flight MediaRecorder before tearing down the stream', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaRecorderMock()
+      installUrlMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+      act(() => { result.current.startRecording() })
+
+      const recorder = result.current.recorder as unknown as FakeMediaRecorder
+      expect(recorder.state).toBe('recording')
+
+      act(() => { result.current.stop() })
+
+      expect(recorder.stop).toHaveBeenCalled()
+      expect(result.current.isRecording).toBe(false)
+      expect(result.current.isActive).toBe(false)
+    })
+  })
 })

--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -232,6 +232,19 @@ describe('useMicrophone', () => {
       act(() => { raf.flush(100) })
       expect(result.current.level).toBe(0)
     })
+
+    it('clears the analyser when stop() is called', async () => {
+      patchRaf()
+      installAudioContextMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone())
+      await act(async () => { await result.current.start() })
+      expect(result.current.analyser).not.toBeNull()
+
+      act(() => { result.current.stop() })
+      expect(result.current.analyser).toBeNull()
+    })
   })
 
   describe('deviceId reactivity', () => {

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -141,6 +141,37 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     }
   })
 
+  // Re-acquire stream when deviceId / constraints change while active
+  const isActiveRef = useRef(false)
+  useEffect(() => {
+    isActiveRef.current = isActive
+  }, [isActive])
+
+  useEffect(() => {
+    if (!isActiveRef.current) return
+    // Tear down current stream + graph, then re-start
+    teardownAudioGraph()
+    const s = streamRef.current
+    if (s) s.getTracks().forEach(t => t.stop())
+    streamRef.current = null
+    // Acquire new stream
+    ;(async () => {
+      try {
+        const audio = buildAudioConstraints(deviceId, constraints)
+        const ns = await navigator.mediaDevices.getUserMedia({ audio })
+        streamRef.current = ns
+        setStream(ns)
+        buildAudioGraph(ns)
+      }
+      catch (e) {
+        setError(e as Error)
+        setIsActive(false)
+        setStream(null)
+      }
+    })()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deviceId, JSON.stringify(constraints)])
+
   useUnmount(() => {
     stop()
     audioContextRef.current?.close().catch(() => {})

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -303,6 +303,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       }
       setIsRecording(false)
       setIsPaused(false)
+      recorderRef.current = null
+      setRecorderState(null)
       stopResolverRef.current?.(finalBlob)
       stopResolverRef.current = null
     }

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -182,6 +182,20 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       setIsActive(true)
       setError(null)
       buildAudioGraph(s)
+      s.getAudioTracks().forEach(t => {
+        t.addEventListener('ended', () => {
+          setError(new Error('Microphone disconnected'))
+          if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+            try {
+              recorderRef.current.stop()
+            }
+            catch {
+              // ignore
+            }
+          }
+          stop()
+        }, { once: true })
+      })
     }
     catch (e) {
       setError(e as Error)

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSupported } from '../useSupported'
+import { useDeepCompareEffect } from '../useDeepCompareEffect'
 import { useEvent } from '../useEvent'
 import { useUnmount } from '../useUnmount'
 import type { UseMicrophone, UseMicrophoneOptions } from './interface'
@@ -221,7 +222,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     isActiveRef.current = isActive
   }, [isActive])
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (!isActiveRef.current)
       return
     // Tear down current stream + graph, then re-start
@@ -247,8 +248,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
         setStream(null)
       }
     })()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deviceId, JSON.stringify(constraints)])
+  }, [deviceId, constraints])
 
   useUnmount(() => {
     stop()

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -156,7 +156,20 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     // Keep analyser + audioContext alive across start/stop cycles
   }, [cancelRaf])
 
+  const stopRecorderIfActive = useCallback(() => {
+    const r = recorderRef.current
+    if (r && r.state !== 'inactive') {
+      try {
+        r.stop()
+      }
+      catch {
+        /* ignore */
+      }
+    }
+  }, [])
+
   const stop = useEvent(() => {
+    stopRecorderIfActive()
     teardownAudioGraph()
     const s = streamRef.current
     if (s)
@@ -185,14 +198,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       s.getAudioTracks().forEach(t => {
         t.addEventListener('ended', () => {
           setError(new Error('Microphone disconnected'))
-          if (recorderRef.current && recorderRef.current.state !== 'inactive') {
-            try {
-              recorderRef.current.stop()
-            }
-            catch {
-              // ignore
-            }
-          }
+          stopRecorderIfActive()
           stop()
         }, { once: true })
       })
@@ -213,6 +219,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     if (!isActiveRef.current)
       return
     // Tear down current stream + graph, then re-start
+    stopRecorderIfActive()
     teardownAudioGraph()
     const s = streamRef.current
     if (s)

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -16,12 +16,14 @@ function buildAudioConstraints(
   extra: MediaTrackConstraints | undefined,
 ): MediaTrackConstraints {
   const merged: MediaTrackConstraints = { ...DEFAULT_AUDIO_CONSTRAINTS, ...(extra || {}) }
-  if (deviceId) merged.deviceId = { exact: deviceId }
+  if (deviceId)
+    merged.deviceId = { exact: deviceId }
   return merged
 }
 
 function getAudioContextCtor(): typeof AudioContext | undefined {
-  if (typeof window === 'undefined') return undefined
+  if (typeof window === 'undefined')
+    return undefined
   return (window as any).AudioContext || (window as any).webkitAudioContext
 }
 
@@ -44,12 +46,14 @@ const MIME_CANDIDATES = [
 function resolveMimeType(preferred: string | undefined): string | undefined {
   const MR = (typeof window !== 'undefined' ? (window as any).MediaRecorder : undefined)
     || (typeof globalThis !== 'undefined' ? (globalThis as any).MediaRecorder : undefined)
-  if (!MR) return undefined
+  if (!MR)
+    return undefined
   if (preferred && typeof MR.isTypeSupported === 'function' && MR.isTypeSupported(preferred)) {
     return preferred
   }
   for (const c of MIME_CANDIDATES) {
-    if (typeof MR.isTypeSupported === 'function' && MR.isTypeSupported(c)) return c
+    if (typeof MR.isTypeSupported === 'function' && MR.isTypeSupported(c))
+      return c
   }
   return undefined
 }
@@ -114,7 +118,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
 
   const tick = useCallback(() => {
     const a = analyserRef.current
-    if (!a) return
+    if (!a)
+      return
     const buf = new Uint8Array(a.frequencyBinCount)
     a.getByteTimeDomainData(buf)
     const now = performance.now()
@@ -127,7 +132,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
 
   const buildAudioGraph = useCallback((s: MediaStream) => {
     const Ctx = getAudioContextCtor()
-    if (!Ctx) return
+    if (!Ctx)
+      return
     if (!audioContextRef.current) {
       audioContextRef.current = new Ctx()
     }
@@ -153,7 +159,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   const stop = useEvent(() => {
     teardownAudioGraph()
     const s = streamRef.current
-    if (s) s.getTracks().forEach(t => t.stop())
+    if (s)
+      s.getTracks().forEach(t => t.stop())
     streamRef.current = null
     setStream(null)
     setIsActive(false)
@@ -165,7 +172,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       setError(err)
       throw err
     }
-    if (streamRef.current) return
+    if (streamRef.current)
+      return
     try {
       const audio = buildAudioConstraints(deviceId, constraints)
       const s = await navigator.mediaDevices.getUserMedia({ audio })
@@ -188,11 +196,13 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   }, [isActive])
 
   useEffect(() => {
-    if (!isActiveRef.current) return
+    if (!isActiveRef.current)
+      return
     // Tear down current stream + graph, then re-start
     teardownAudioGraph()
     const s = streamRef.current
-    if (s) s.getTracks().forEach(t => t.stop())
+    if (s)
+      s.getTracks().forEach(t => t.stop())
     streamRef.current = null
     // Acquire new stream
     ;(async () => {
@@ -230,8 +240,10 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   }, [isSupported])
 
   const startRecording = useEvent(() => {
-    if (!streamRef.current) return
-    if (recorderRef.current && recorderRef.current.state !== 'inactive') return
+    if (!streamRef.current)
+      return
+    if (recorderRef.current && recorderRef.current.state !== 'inactive')
+      return
 
     revokeAudioUrl()
     setBlob(null)
@@ -250,7 +262,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     setResolvedMime(mime || null)
 
     recorder.ondataavailable = (e: BlobEvent) => {
-      if (e.data && e.data.size > 0) chunksRef.current.push(e.data)
+      if (e.data && e.data.size > 0)
+        chunksRef.current.push(e.data)
     }
     recorder.onstop = () => {
       const finalBlob = chunksRef.current.length
@@ -275,8 +288,9 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
 
   const stopRecording = useEvent((): Promise<Blob | null> => {
     const r = recorderRef.current
-    if (!r || r.state === 'inactive') return Promise.resolve(null)
-    return new Promise<Blob | null>((resolve) => {
+    if (!r || r.state === 'inactive')
+      return Promise.resolve(null)
+    return new Promise<Blob | null>(resolve => {
       stopResolverRef.current = resolve
       r.stop()
     })

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -217,6 +217,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     audioContextRef.current = null
     analyserRef.current = null
     setAnalyser(null)
+    revokeAudioUrl()
   })
 
   const noop = useCallback(() => {}, [])

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -1,6 +1,7 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSupported } from '../useSupported'
 import { useEvent } from '../useEvent'
+import { useUnmount } from '../useUnmount'
 import type { UseMicrophone, UseMicrophoneOptions } from './interface'
 
 const DEFAULT_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
@@ -8,20 +9,37 @@ const DEFAULT_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
   noiseSuppression: true,
   autoGainControl: true,
 }
+const DEFAULT_LEVEL_INTERVAL = 100
 
 function buildAudioConstraints(
   deviceId: string | undefined,
   extra: MediaTrackConstraints | undefined,
 ): MediaTrackConstraints {
   const merged: MediaTrackConstraints = { ...DEFAULT_AUDIO_CONSTRAINTS, ...(extra || {}) }
-  if (deviceId) {
-    merged.deviceId = { exact: deviceId }
-  }
+  if (deviceId) merged.deviceId = { exact: deviceId }
   return merged
 }
 
+function getAudioContextCtor(): typeof AudioContext | undefined {
+  if (typeof window === 'undefined') return undefined
+  return (window as any).AudioContext || (window as any).webkitAudioContext
+}
+
+function computeRms(buf: Uint8Array): number {
+  let sumSquares = 0
+  for (let i = 0; i < buf.length; i++) {
+    const v = (buf[i] - 128) / 128
+    sumSquares += v * v
+  }
+  return Math.min(1, Math.sqrt(sumSquares / buf.length))
+}
+
 export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {}) => {
-  const { deviceId, constraints } = options
+  const {
+    deviceId,
+    constraints,
+    levelInterval = DEFAULT_LEVEL_INTERVAL,
+  } = options
 
   const isSupported = useSupported(
     () => typeof navigator !== 'undefined'
@@ -32,13 +50,70 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   const [isActive, setIsActive] = useState(false)
   const [stream, setStream] = useState<MediaStream | null>(null)
   const [error, setError] = useState<Error | null>(null)
+  const [level, setLevel] = useState(0)
+  const [analyser, setAnalyser] = useState<AnalyserNode | null>(null)
+
   const streamRef = useRef<MediaStream | null>(null)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const lastLevelEmitRef = useRef<number>(-Infinity)
+  const levelIntervalRef = useRef<number>(levelInterval)
+
+  useEffect(() => {
+    levelIntervalRef.current = levelInterval
+  }, [levelInterval])
+
+  const cancelRaf = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+  }, [])
+
+  const tick = useCallback(() => {
+    const a = analyserRef.current
+    if (!a) return
+    const buf = new Uint8Array(a.frequencyBinCount)
+    a.getByteTimeDomainData(buf)
+    const now = performance.now()
+    if (now - lastLevelEmitRef.current >= levelIntervalRef.current) {
+      lastLevelEmitRef.current = now
+      setLevel(computeRms(buf))
+    }
+    rafRef.current = requestAnimationFrame(tick)
+  }, [])
+
+  const buildAudioGraph = useCallback((s: MediaStream) => {
+    const Ctx = getAudioContextCtor()
+    if (!Ctx) return
+    if (!audioContextRef.current) {
+      audioContextRef.current = new Ctx()
+    }
+    const ctx = audioContextRef.current
+    sourceRef.current = ctx.createMediaStreamSource(s)
+    const a = ctx.createAnalyser()
+    a.fftSize = 2048
+    a.smoothingTimeConstant = 0.8
+    sourceRef.current.connect(a)
+    analyserRef.current = a
+    setAnalyser(a)
+    lastLevelEmitRef.current = -Infinity
+    rafRef.current = requestAnimationFrame(tick)
+  }, [tick])
+
+  const teardownAudioGraph = useCallback(() => {
+    cancelRaf()
+    sourceRef.current?.disconnect()
+    sourceRef.current = null
+    // Keep analyser + audioContext alive across start/stop cycles
+  }, [cancelRaf])
 
   const stop = useEvent(() => {
+    teardownAudioGraph()
     const s = streamRef.current
-    if (s) {
-      s.getTracks().forEach(t => t.stop())
-    }
+    if (s) s.getTracks().forEach(t => t.stop())
     streamRef.current = null
     setStream(null)
     setIsActive(false)
@@ -50,9 +125,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       setError(err)
       throw err
     }
-    if (streamRef.current) {
-      return
-    }
+    if (streamRef.current) return
     try {
       const audio = buildAudioConstraints(deviceId, constraints)
       const s = await navigator.mediaDevices.getUserMedia({ audio })
@@ -60,11 +133,20 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       setStream(s)
       setIsActive(true)
       setError(null)
+      buildAudioGraph(s)
     }
     catch (e) {
       setError(e as Error)
       throw e
     }
+  })
+
+  useUnmount(() => {
+    stop()
+    audioContextRef.current?.close().catch(() => {})
+    audioContextRef.current = null
+    analyserRef.current = null
+    setAnalyser(null)
   })
 
   const noop = useCallback(() => {}, [])
@@ -74,8 +156,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     isSupported,
     isActive,
     stream,
-    level: 0,
-    analyser: null,
+    level,
+    analyser,
     error,
 
     isRecording: false,

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -1,23 +1,82 @@
+import { useCallback, useRef, useState } from 'react'
 import { useSupported } from '../useSupported'
+import { useEvent } from '../useEvent'
 import type { UseMicrophone, UseMicrophoneOptions } from './interface'
 
-const noop = () => {}
-const asyncNoop = async () => {}
+const DEFAULT_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
+}
 
-export const useMicrophone: UseMicrophone = (_options: UseMicrophoneOptions = {}) => {
+function buildAudioConstraints(
+  deviceId: string | undefined,
+  extra: MediaTrackConstraints | undefined,
+): MediaTrackConstraints {
+  const merged: MediaTrackConstraints = { ...DEFAULT_AUDIO_CONSTRAINTS, ...(extra || {}) }
+  if (deviceId) {
+    merged.deviceId = { exact: deviceId }
+  }
+  return merged
+}
+
+export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {}) => {
+  const { deviceId, constraints } = options
+
   const isSupported = useSupported(
     () => typeof navigator !== 'undefined'
       && !!navigator.mediaDevices
       && typeof navigator.mediaDevices.getUserMedia === 'function',
   )
 
+  const [isActive, setIsActive] = useState(false)
+  const [stream, setStream] = useState<MediaStream | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+
+  const stop = useEvent(() => {
+    const s = streamRef.current
+    if (s) {
+      s.getTracks().forEach(t => t.stop())
+    }
+    streamRef.current = null
+    setStream(null)
+    setIsActive(false)
+  })
+
+  const start = useEvent(async () => {
+    if (!isSupported) {
+      const err = new Error('Microphone not supported in this environment')
+      setError(err)
+      throw err
+    }
+    if (streamRef.current) {
+      return
+    }
+    try {
+      const audio = buildAudioConstraints(deviceId, constraints)
+      const s = await navigator.mediaDevices.getUserMedia({ audio })
+      streamRef.current = s
+      setStream(s)
+      setIsActive(true)
+      setError(null)
+    }
+    catch (e) {
+      setError(e as Error)
+      throw e
+    }
+  })
+
+  const noop = useCallback(() => {}, [])
+  const asyncNullResult = useCallback(async () => null, [])
+
   return {
     isSupported,
-    isActive: false,
-    stream: null,
+    isActive,
+    stream,
     level: 0,
     analyser: null,
-    error: null,
+    error,
 
     isRecording: false,
     isPaused: false,
@@ -26,10 +85,10 @@ export const useMicrophone: UseMicrophone = (_options: UseMicrophoneOptions = {}
     mimeType: null,
     recorder: null,
 
-    start: asyncNoop,
-    stop: noop,
+    start,
+    stop,
     startRecording: noop,
-    stopRecording: async () => null,
+    stopRecording: asyncNullResult,
     pauseRecording: noop,
     resumeRecording: noop,
   } as const

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -266,8 +266,10 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   }, [isSupported])
 
   const startRecording = useEvent(() => {
-    if (!streamRef.current)
+    if (!streamRef.current) {
+      setError(new Error('useMicrophone: call start() before startRecording()'))
       return
+    }
     if (recorderRef.current && recorderRef.current.state !== 'inactive')
       return
 

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -153,7 +153,9 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     cancelRaf()
     sourceRef.current?.disconnect()
     sourceRef.current = null
-    // Keep analyser + audioContext alive across start/stop cycles
+    analyserRef.current = null
+    setAnalyser(null)
+    // AudioContext stays alive across start/stop cycles (cheap to keep, expensive to recreate).
   }, [cancelRaf])
 
   const stopRecorderIfActive = useCallback(() => {
@@ -252,8 +254,6 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     stop()
     audioContextRef.current?.close().catch(() => {})
     audioContextRef.current = null
-    analyserRef.current = null
-    setAnalyser(null)
     revokeAudioUrl()
   })
 

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -220,8 +220,6 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     revokeAudioUrl()
   })
 
-  const noop = useCallback(() => {}, [])
-
   const startRecording = useEvent(() => {
     if (!streamRef.current) return
     if (recorderRef.current && recorderRef.current.state !== 'inactive') return
@@ -275,6 +273,22 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     })
   })
 
+  const pauseRecording = useEvent(() => {
+    const r = recorderRef.current
+    if (r && r.state === 'recording') {
+      r.pause()
+      setIsPaused(true)
+    }
+  })
+
+  const resumeRecording = useEvent(() => {
+    const r = recorderRef.current
+    if (r && r.state === 'paused') {
+      r.resume()
+      setIsPaused(false)
+    }
+  })
+
   return {
     isSupported,
     isActive,
@@ -294,8 +308,8 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     stop,
     startRecording,
     stopRecording,
-    pauseRecording: noop,
-    resumeRecording: noop,
+    pauseRecording,
+    resumeRecording,
   } as const
 }
 

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -59,6 +59,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     deviceId,
     constraints,
     levelInterval = DEFAULT_LEVEL_INTERVAL,
+    autoStart,
   } = options
 
   const isSupported = useSupported(
@@ -219,6 +220,14 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     setAnalyser(null)
     revokeAudioUrl()
   })
+
+  const autoStartRef = useRef(autoStart)
+  useEffect(() => {
+    if (autoStartRef.current && isSupported) {
+      start().catch(() => {})
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSupported])
 
   const startRecording = useEvent(() => {
     if (!streamRef.current) return

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -34,6 +34,26 @@ function computeRms(buf: Uint8Array): number {
   return Math.min(1, Math.sqrt(sumSquares / buf.length))
 }
 
+const MIME_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/mp4',
+  'audio/ogg;codecs=opus',
+]
+
+function resolveMimeType(preferred: string | undefined): string | undefined {
+  const MR = (typeof window !== 'undefined' ? (window as any).MediaRecorder : undefined)
+    || (typeof globalThis !== 'undefined' ? (globalThis as any).MediaRecorder : undefined)
+  if (!MR) return undefined
+  if (preferred && typeof MR.isTypeSupported === 'function' && MR.isTypeSupported(preferred)) {
+    return preferred
+  }
+  for (const c of MIME_CANDIDATES) {
+    if (typeof MR.isTypeSupported === 'function' && MR.isTypeSupported(c)) return c
+  }
+  return undefined
+}
+
 export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {}) => {
   const {
     deviceId,
@@ -53,6 +73,18 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   const [level, setLevel] = useState(0)
   const [analyser, setAnalyser] = useState<AnalyserNode | null>(null)
 
+  const [isRecording, setIsRecording] = useState(false)
+  const [isPaused, setIsPaused] = useState(false)
+  const [blob, setBlob] = useState<Blob | null>(null)
+  const [audioUrl, setAudioUrl] = useState<string | null>(null)
+  const [recorderState, setRecorderState] = useState<MediaRecorder | null>(null)
+  const [resolvedMime, setResolvedMime] = useState<string | null>(null)
+
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const audioUrlRef = useRef<string | null>(null)
+  const stopResolverRef = useRef<((b: Blob | null) => void) | null>(null)
+
   const streamRef = useRef<MediaStream | null>(null)
   const audioContextRef = useRef<AudioContext | null>(null)
   const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
@@ -69,6 +101,13 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     if (rafRef.current != null) {
       cancelAnimationFrame(rafRef.current)
       rafRef.current = null
+    }
+  }, [])
+
+  const revokeAudioUrl = useCallback(() => {
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current)
+      audioUrlRef.current = null
     }
   }, [])
 
@@ -181,7 +220,59 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
   })
 
   const noop = useCallback(() => {}, [])
-  const asyncNullResult = useCallback(async () => null, [])
+
+  const startRecording = useEvent(() => {
+    if (!streamRef.current) return
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') return
+
+    revokeAudioUrl()
+    setBlob(null)
+    setAudioUrl(null)
+    chunksRef.current = []
+
+    const mime = resolveMimeType(options.mimeType)
+    const MR = (window as any).MediaRecorder as typeof MediaRecorder
+    if (!MR) {
+      setError(new Error('MediaRecorder is not supported'))
+      return
+    }
+    const recorder = new MR(streamRef.current, mime ? { mimeType: mime } : undefined)
+    recorderRef.current = recorder
+    setRecorderState(recorder)
+    setResolvedMime(mime || null)
+
+    recorder.ondataavailable = (e: BlobEvent) => {
+      if (e.data && e.data.size > 0) chunksRef.current.push(e.data)
+    }
+    recorder.onstop = () => {
+      const finalBlob = chunksRef.current.length
+        ? new Blob(chunksRef.current, { type: mime || chunksRef.current[0].type })
+        : null
+      if (finalBlob) {
+        const url = URL.createObjectURL(finalBlob)
+        audioUrlRef.current = url
+        setBlob(finalBlob)
+        setAudioUrl(url)
+      }
+      setIsRecording(false)
+      setIsPaused(false)
+      stopResolverRef.current?.(finalBlob)
+      stopResolverRef.current = null
+    }
+
+    recorder.start()
+    setIsRecording(true)
+    setIsPaused(false)
+  })
+
+  const stopRecording = useEvent((): Promise<Blob | null> => {
+    const r = recorderRef.current
+    if (!r || r.state === 'inactive') return Promise.resolve(null)
+    return new Promise<Blob | null>((resolve) => {
+      stopResolverRef.current = resolve
+      r.stop()
+    })
+  })
 
   return {
     isSupported,
@@ -191,17 +282,17 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     analyser,
     error,
 
-    isRecording: false,
-    isPaused: false,
-    blob: null,
-    audioUrl: null,
-    mimeType: null,
-    recorder: null,
+    isRecording,
+    isPaused,
+    blob,
+    audioUrl,
+    mimeType: resolvedMime,
+    recorder: recorderState,
 
     start,
     stop,
-    startRecording: noop,
-    stopRecording: asyncNullResult,
+    startRecording,
+    stopRecording,
     pauseRecording: noop,
     resumeRecording: noop,
   } as const

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -1,0 +1,38 @@
+import { useSupported } from '../useSupported'
+import type { UseMicrophone, UseMicrophoneOptions } from './interface'
+
+const noop = () => {}
+const asyncNoop = async () => {}
+
+export const useMicrophone: UseMicrophone = (_options: UseMicrophoneOptions = {}) => {
+  const isSupported = useSupported(
+    () => typeof navigator !== 'undefined'
+      && !!navigator.mediaDevices
+      && typeof navigator.mediaDevices.getUserMedia === 'function',
+  )
+
+  return {
+    isSupported,
+    isActive: false,
+    stream: null,
+    level: 0,
+    analyser: null,
+    error: null,
+
+    isRecording: false,
+    isPaused: false,
+    blob: null,
+    audioUrl: null,
+    mimeType: null,
+    recorder: null,
+
+    start: asyncNoop,
+    stop: noop,
+    startRecording: noop,
+    stopRecording: async () => null,
+    pauseRecording: noop,
+    resumeRecording: noop,
+  } as const
+}
+
+export type { UseMicrophoneOptions, UseMicrophoneReturn } from './interface'

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -363,7 +363,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     stopRecording,
     pauseRecording,
     resumeRecording,
-  } as const
+  }
 }
 
 export type { UseMicrophoneOptions, UseMicrophoneReturn } from './interface'

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -179,6 +179,16 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     setIsActive(false)
   })
 
+  const attachTrackEndedListeners = useEvent((s: MediaStream) => {
+    s.getAudioTracks().forEach(t => {
+      t.addEventListener('ended', () => {
+        setError(new Error('Microphone disconnected'))
+        stopRecorderIfActive()
+        stop()
+      }, { once: true })
+    })
+  })
+
   const start = useEvent(async () => {
     if (!isSupported) {
       const err = new Error('Microphone not supported in this environment')
@@ -195,13 +205,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
       setIsActive(true)
       setError(null)
       buildAudioGraph(s)
-      s.getAudioTracks().forEach(t => {
-        t.addEventListener('ended', () => {
-          setError(new Error('Microphone disconnected'))
-          stopRecorderIfActive()
-          stop()
-        }, { once: true })
-      })
+      attachTrackEndedListeners(s)
     }
     catch (e) {
       setError(e as Error)
@@ -233,6 +237,7 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
         streamRef.current = ns
         setStream(ns)
         buildAudioGraph(ns)
+        attachTrackEndedListeners(ns)
       }
       catch (e) {
         setError(e as Error)

--- a/packages/core/src/useMicrophone/interface.ts
+++ b/packages/core/src/useMicrophone/interface.ts
@@ -1,0 +1,32 @@
+export interface UseMicrophoneOptions {
+  deviceId?: string
+  constraints?: MediaTrackConstraints
+  levelInterval?: number
+  mimeType?: string
+  autoStart?: boolean
+}
+
+export interface UseMicrophoneReturn {
+  readonly isSupported: boolean
+  readonly isActive: boolean
+  readonly stream: MediaStream | null
+  readonly level: number
+  readonly analyser: AnalyserNode | null
+  readonly error: Error | null
+
+  readonly isRecording: boolean
+  readonly isPaused: boolean
+  readonly blob: Blob | null
+  readonly audioUrl: string | null
+  readonly mimeType: string | null
+  readonly recorder: MediaRecorder | null
+
+  readonly start: () => Promise<void>
+  readonly stop: () => void
+  readonly startRecording: () => void
+  readonly stopRecording: () => Promise<Blob | null>
+  readonly pauseRecording: () => void
+  readonly resumeRecording: () => void
+}
+
+export type UseMicrophone = (options?: UseMicrophoneOptions) => UseMicrophoneReturn

--- a/packages/core/src/useMicrophone/interface.ts
+++ b/packages/core/src/useMicrophone/interface.ts
@@ -1,32 +1,93 @@
+/**
+ * @title UseMicrophoneOptions
+ */
 export interface UseMicrophoneOptions {
+  /**
+   * @zh 指定要使用的麦克风设备 ID；激活状态下变化会自动重新获取流
+   * @zh-Hant 指定要使用的麥克風裝置 ID；啟動狀態下變化會自動重新取得串流
+   * @en Specific microphone deviceId; re-acquires the stream when changed while active
+   */
   deviceId?: string
+  /**
+   * @zh 与默认音频约束合并的额外 MediaTrackConstraints；deviceId 优先
+   * @zh-Hant 與預設音訊約束合併的額外 MediaTrackConstraints；deviceId 優先
+   * @en Extra MediaTrackConstraints merged with the defaults; deviceId above takes precedence
+   */
   constraints?: MediaTrackConstraints
+  /**
+   * @zh 音量级别状态更新的节流间隔（毫秒）
+   * @zh-Hant 音量等級狀態更新的節流間隔（毫秒）
+   * @en Throttle interval (ms) for level state updates
+   * @default 100
+   */
   levelInterval?: number
+  /**
+   * @zh MediaRecorder 的首选 mime 类型；不受支持时自动回退
+   * @zh-Hant MediaRecorder 的首選 mime 類型；不支援時自動回退
+   * @en Preferred MediaRecorder mime type; falls back to auto-selection if unsupported
+   */
   mimeType?: string
+  /**
+   * @zh 挂载时自动打开麦克风
+   * @zh-Hant 掛載時自動開啟麥克風
+   * @en Automatically open the microphone on mount
+   * @default false
+   */
   autoStart?: boolean
 }
 
+/**
+ * @title useMicrophone
+ * @returns 包含麦克风流、音量级别、录音控制等的对象
+ * @returns_en An object exposing the microphone stream, audio level, recording controls, and lifecycle methods
+ * @returns_zh-Hant 包含麥克風串流、音量等級、錄音控制等的物件
+ */
+export type UseMicrophone = (
+  /**
+   * @zh 可选配置
+   * @zh-Hant 可選配置
+   * @en Optional configuration
+   */
+  options?: UseMicrophoneOptions
+) => UseMicrophoneReturn
+
 export interface UseMicrophoneReturn {
+  /** @zh 浏览器是否支持麦克风访问 @zh-Hant 瀏覽器是否支援麥克風存取 @en Whether the browser supports microphone access */
   readonly isSupported: boolean
+  /** @zh 麦克风是否已开启 @zh-Hant 麥克風是否已開啟 @en Whether the microphone stream is open */
   readonly isActive: boolean
+  /** @zh 当前 MediaStream @zh-Hant 目前的 MediaStream @en The current MediaStream, or null when inactive */
   readonly stream: MediaStream | null
+  /** @zh 当前音量级别（0-1，RMS） @zh-Hant 目前音量等級（0-1，RMS） @en Current normalized audio level (0..1, RMS, throttled) */
   readonly level: number
+  /** @zh AnalyserNode 实例，供高级用例使用 @zh-Hant AnalyserNode 實例，供進階用例使用 @en The AnalyserNode for advanced consumers */
   readonly analyser: AnalyserNode | null
+  /** @zh 最近一次错误 @zh-Hant 最近一次錯誤 @en Most recent error, if any */
   readonly error: Error | null
 
+  /** @zh 是否正在录音 @zh-Hant 是否正在錄音 @en Whether recording is in progress */
   readonly isRecording: boolean
+  /** @zh 录音是否处于暂停状态 @zh-Hant 錄音是否處於暫停狀態 @en Whether recording is paused */
   readonly isPaused: boolean
+  /** @zh 最近一次录音生成的 Blob @zh-Hant 最近一次錄音產生的 Blob @en Blob produced by the most recent stopRecording() */
   readonly blob: Blob | null
+  /** @zh 由 Hook 管理生命周期的对象 URL @zh-Hant 由 Hook 管理生命週期的物件 URL @en Hook-managed object URL; revoked on next record / on unmount */
   readonly audioUrl: string | null
+  /** @zh 实际使用的 mime 类型 @zh-Hant 實際使用的 mime 類型 @en The mime type actually used by MediaRecorder */
   readonly mimeType: string | null
+  /** @zh MediaRecorder 实例 @zh-Hant MediaRecorder 實例 @en The underlying MediaRecorder instance, when recording */
   readonly recorder: MediaRecorder | null
 
+  /** @zh 打开麦克风 @zh-Hant 開啟麥克風 @en Open the microphone */
   readonly start: () => Promise<void>
+  /** @zh 关闭麦克风 @zh-Hant 關閉麥克風 @en Close the microphone */
   readonly stop: () => void
+  /** @zh 开始录音（需先调用 start） @zh-Hant 開始錄音（須先呼叫 start） @en Begin recording (requires start() first) */
   readonly startRecording: () => void
+  /** @zh 停止录音并返回 Blob @zh-Hant 停止錄音並返回 Blob @en Stop recording; resolves with the captured Blob */
   readonly stopRecording: () => Promise<Blob | null>
+  /** @zh 暂停录音 @zh-Hant 暫停錄音 @en Pause recording */
   readonly pauseRecording: () => void
+  /** @zh 恢复录音 @zh-Hant 恢復錄音 @en Resume recording */
   readonly resumeRecording: () => void
 }
-
-export type UseMicrophone = (options?: UseMicrophoneOptions) => UseMicrophoneReturn


### PR DESCRIPTION
Closes #197

## Summary

Adds a new `useMicrophone` hook to `@reactuses/core`. One hook that wraps three common microphone concerns:

- **Live stream** — `start()` / `stop()` open/close the mic via `getUserMedia`
- **Audio level** — throttled RMS level (0–1) suitable for VU-meter UI; raw `AnalyserNode` also exposed
- **Recording** — `MediaRecorder`-based capture with auto-selected mime type, returning a `Blob` and a hook-managed `audioUrl`

The live-stream controls and recording controls are independent, so consumers can show a level meter without recording and can start/stop recordings without dropping the mic.

## Usage

```tsx
const {
  isSupported,
  // live stream
  isActive, stream, level, analyser, error,
  // recording
  isRecording, isPaused, blob, audioUrl, mimeType, recorder,
  // controls
  start, stop,
  startRecording, stopRecording, pauseRecording, resumeRecording,
} = useMicrophone({
  deviceId,        // target a specific mic
  constraints,     // merged with defaults (echoCancellation, noiseSuppression, autoGainControl)
  levelInterval,   // throttle for \`level\` state updates, default 100ms
  mimeType,        // preferred MediaRecorder mime; falls back if unsupported
  autoStart,       // open mic on mount, default false
})
```

Typical flow:

```tsx
await start()                       // mic open, level meter live, no recording yet
startRecording()                    // begin capture
const blob = await stopRecording()  // returns Blob; mic stays open for instant re-take
stop()                              // close the mic
```

## Design choices

- **\`startRecording\` requires \`start()\` first** (no implicit auto-start). Keeps the two control surfaces honest and routes all permission failures through one entry point.
- **Level meter throttled by default** (100ms / ~10Hz) so the consuming component doesn't re-render 60×/sec. The raw \`AnalyserNode\` is exposed for consumers who want to read frequency data without paying the re-render cost.
- **Mime auto-selection:** preferred → \`audio/webm;codecs=opus\` → \`audio/webm\` → \`audio/mp4\` → \`audio/ogg;codecs=opus\` → browser default. Resolved mime returned as \`mimeType\` so consumers know what they got.
- **\`audioUrl\` lifecycle is hook-managed** — revoked on next recording and on unmount, so consumers can't leak object URLs.
- **\`deviceId\` / \`constraints\` are reactive** — changing them while active tears down the current stream and re-acquires.
- **Track-ended handling** — mid-stream device disconnect sets \`error\`, stops any in-flight recording, and flips \`isActive\` to false.
- **Device enumeration intentionally deferred to \`useMediaDevices\`** — no duplication.

## Not done yet (follow-up)
- Website docs page at \`packages/website-astro/src/content/docs/browser/useMicrophone.mdx\` with a runnable demo, plus zh-Hans / zh-Hant translations
- Entry in \`scripts/hook-registry.json\` so blog posts can link to the canonical URL

Happy to open a follow-up PR for those once this hook is merged.