### PR TITLE
Implement read-only `useClipboard`

### DIFF
--- a/packages/core/src/useClipboard/index.ts
+++ b/packages/core/src/useClipboard/index.ts
@@ -9,7 +9,14 @@ export const useClipboard: UseClipboard = (options = { read: false }): readonly 
 ] => {
   const [text, setText] = useState('')
 
+  const read = options.read ?? false
+
   const updateText = useCallback(async () => {
+    // if read-only, do not run
+    if (read) {
+      return
+    }
+
     // Check if document is focused before attempting to read clipboard
     if (!document.hasFocus()) {
       return
@@ -23,7 +30,7 @@ export const useClipboard: UseClipboard = (options = { read: false }): readonly 
       // Handle cases where clipboard access is denied or unavailable
       console.warn('Failed to read clipboard:', error)
     }
-  }, [])
+  }, [read])
 
   useEventListener('copy', updateText)
   useEventListener('cut', updateText)

--- a/packages/core/src/useClipboard/index.ts
+++ b/packages/core/src/useClipboard/index.ts
@@ -3,7 +3,7 @@ import { useEventListener } from '../useEventListener'
 import { defaultWindow } from '../utils/browser'
 import type { UseClipboard } from './interface'
 
-export const useClipboard: UseClipboard = (): readonly [
+export const useClipboard: UseClipboard = (options = { read: false }): readonly [
   string,
   (txt: string) => Promise<void>,
 ] => {

--- a/packages/core/src/useClipboard/interface.ts
+++ b/packages/core/src/useClipboard/interface.ts
@@ -4,4 +4,6 @@
  * @returns 返回只读元组.
  * @returns_zh-Hant 返回唯讀元組.
  */
-export type UseClipboard = () => readonly [string, (txt: string) => Promise<void>]
+export type UseClipboard = (options?: {
+  read?: boolean
+}) => readonly [string, (txt: string) => Promise<void>]


### PR DESCRIPTION
## Description
Closes #200

## Type of Change
- [ ] Bug fix
- [ ] New hook
- [x] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [ ] I have added tests for my changes
- [ ] All existing tests pass
- [ ] I have updated the documentation

***

The only thing left to do is to update the existing documentation. There are many, I mean, *many* markdown files. Some of them are for Docusaurus, some of them are for Astro. I was going to update it but I'm kind of confused. Can you inform me about how the docs build?