### PR TITLE
fix(useInterval): clear a manually resumed interval on unmount

### DIFF
--- a/packages/core/src/useInterval/index.spec.ts
+++ b/packages/core/src/useInterval/index.spec.ts
@@ -125,4 +125,35 @@ describe('useInterval', () => {
     jest.advanceTimersByTime(70)
     expect(callback).toHaveBeenCalledTimes(1)
   })
+
+  it('should clear a manually resumed interval on unmount', () => {
+    const callback = jest.fn()
+    const { result, unmount } = renderHook(() =>
+      useInterval(callback, 50, { controls: true }),
+    )
+
+    result.current.resume()
+    jest.advanceTimersByTime(50)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    unmount()
+    callback.mockClear()
+
+    jest.advanceTimersByTime(500)
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not leave an orphan interval when resume is called twice', () => {
+    const callback = jest.fn()
+    const { result } = renderHook(() =>
+      useInterval(callback, 50, { controls: true }),
+    )
+
+    result.current.resume()
+    result.current.resume()
+    result.current.pause()
+
+    jest.advanceTimersByTime(500)
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
 })

--- a/packages/core/src/useInterval/index.ts
+++ b/packages/core/src/useInterval/index.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useEvent } from '../useEvent'
 import { useLatest } from '../useLatest'
+import { useUnmount } from '../useUnmount'
 import { defaultOptions } from '../utils/defaults'
 import type { UseInterval } from './interface'
 
@@ -18,10 +19,16 @@ export const useInterval: UseInterval = (
   const timer = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const clean = () => {
-    timer.current && clearInterval(timer.current)
+    if (timer.current) {
+      clearInterval(timer.current)
+      timer.current = null
+    }
   }
 
   const resume = useEvent(() => {
+    // Drop a running timer first — otherwise its id is overwritten below and
+    // neither pause() nor unmount can reach it again.
+    clean()
     isActive.current = true
     timer.current = setInterval(() => savedCallback.current(), delay || 0)
   })
@@ -48,6 +55,11 @@ export const useInterval: UseInterval = (
     return undefined
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [delay, immediate])
+
+  // The effect above bails out before registering a cleanup when `controls` is
+  // set, so a timer started by resume() would outlive the component. Clear it on
+  // unmount whichever mode the hook runs in.
+  useUnmount(clean)
 
   return {
     isActive,


### PR DESCRIPTION
## Description

`useInterval` never clears its timer on unmount when `controls: true` is used.

The effect that owns the cleanup bails out before it can register one:

```ts
if (controls) {
  return
}
```

So an interval started through `resume()` keeps firing after the component is
gone. The hook's docs promise the opposite:

> The interval is automatically cleared on component unmount.

To reproduce: mount with `{ controls: true }`, call `resume()`, unmount, then
advance the timers. The callback keeps running — 10 more calls over 500ms at a
50ms delay in the test I added.

I put the unmount cleanup in its own mount-scoped effect rather than returning
`clean` from the existing one. That keeps the current `delay`-change behaviour
untouched: in manual mode, updating `delay` still doesn't stop a running timer,
which felt like a separate decision from fixing the leak.

While I was in there — `resume()` overwrote `timer.current` without clearing the
previous timer, so calling it twice orphaned the first interval and neither
`pause()` nor the unmount cleanup could reach it afterwards. It now clears first.

## Type of Change
- [x] Bug fix
- [ ] New hook
- [ ] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation

No doc change: the existing page already describes the fixed behaviour.

Two tests added to `useInterval/index.spec.ts` — one for the unmount leak, one
for the double-`resume()` orphan. Both fail on `main` and pass here; the other 9
in that file are untouched.
