### PR TITLE
fix(useMicrophone): reset level to 0 on stop()

### DIFF
--- a/packages/core/src/useMicrophone/index.spec.ts
+++ b/packages/core/src/useMicrophone/index.spec.ts
@@ -245,6 +245,23 @@ describe('useMicrophone', () => {
       act(() => { result.current.stop() })
       expect(result.current.analyser).toBeNull()
     })
+
+    it('resets level to 0 when stop() is called', async () => {
+      const raf = patchRaf()
+      installAudioContextMock()
+      installMediaDevicesMock(jest.fn().mockResolvedValue(makeMockStream()))
+
+      const { result } = renderHook(() => useMicrophone({ levelInterval: 100 }))
+      await act(async () => { await result.current.start() })
+
+      const analyser = result.current.analyser as unknown as FakeAnalyser
+      analyser.nextData = new Array(analyser.frequencyBinCount).fill(255)
+      act(() => { raf.flush(0) })
+      expect(result.current.level).toBeGreaterThan(0)
+
+      act(() => { result.current.stop() })
+      expect(result.current.level).toBe(0)
+    })
   })
 
   describe('deviceId reactivity', () => {

--- a/packages/core/src/useMicrophone/index.ts
+++ b/packages/core/src/useMicrophone/index.ts
@@ -156,6 +156,9 @@ export const useMicrophone: UseMicrophone = (options: UseMicrophoneOptions = {})
     sourceRef.current = null
     analyserRef.current = null
     setAnalyser(null)
+    // The rAF loop is the only thing that writes `level`, so without this the
+    // meter stays frozen at whatever it read on the last frame before teardown.
+    setLevel(0)
     // AudioContext stays alive across start/stop cycles (cheap to keep, expensive to recreate).
   }, [cancelRaf])
 


### PR DESCRIPTION
## Description

After `stop()`, `useMicrophone` leaves `level` frozen at the last value it
measured instead of dropping to 0.

`teardownAudioGraph()` cancels the rAF loop, disconnects the source and nulls the
analyser — but that loop is the only writer of `level`, so whatever it read on
the final frame stays in state indefinitely. A volume meter bound to `level`
keeps showing input after the microphone has been released, which reads as "still
recording" to the user.

Easy to see in the demo: talk into the mic until the bar moves, hit stop, and the
bar stays where it was.

One line in `teardownAudioGraph()`. It also covers the device-switch path, where
the graph is torn down and rebuilt — the meter now resets instead of briefly
showing the old device's level against the new stream.

## Type of Change
- [x] Bug fix
- [ ] New hook
- [ ] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation

No doc change — this is the behaviour the docs already imply.

The new test sits next to `clears the analyser when stop() is called`, which
covers the analyser but never looked at `level`. It uses the existing mock
harness in that file and fails on `main` with `0.9921875` instead of `0`.
