### PR TITLE
fix(useElementByPoint): avoid a re-render on every frame in multiple mode

### DIFF
--- a/packages/core/src/useElementByPoint/index.spec.ts
+++ b/packages/core/src/useElementByPoint/index.spec.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react'
+import { useElementByPoint } from '.'
+
+function patchRaf() {
+  let callbacks: Array<(t: number) => void> = []
+  ;(global as any).requestAnimationFrame = (cb: (t: number) => void) => {
+    callbacks.push(cb)
+    return callbacks.length
+  }
+  ;(global as any).cancelAnimationFrame = jest.fn()
+  return {
+    flush() {
+      const cbs = callbacks
+      callbacks = []
+      cbs.forEach(cb => cb(0))
+    },
+  }
+}
+
+describe('useElementByPoint', () => {
+  it('reports the element under the point', () => {
+    const raf = patchRaf()
+    const el = document.createElement('div')
+    const doc = { elementFromPoint: () => el } as unknown as Document
+
+    const { result } = renderHook(() => useElementByPoint({ x: 1, y: 2, document: doc }))
+
+    act(() => { raf.flush() })
+    expect(result.current.element).toBe(el)
+  })
+
+  it('does not re-render while the hit list is unchanged in multiple mode', () => {
+    const raf = patchRaf()
+    const el = document.createElement('div')
+    // A real document returns a new array on every call, even when the pointer
+    // has not moved.
+    const doc = { elementsFromPoint: () => [el] } as unknown as Document
+
+    let renders = 0
+    renderHook(() => {
+      renders++
+      return useElementByPoint({ x: 1, y: 2, document: doc, multiple: true })
+    })
+
+    // First frame legitimately moves the state from null to the hit list.
+    act(() => { raf.flush() })
+    const settled = renders
+
+    act(() => { raf.flush() })
+    act(() => { raf.flush() })
+    act(() => { raf.flush() })
+
+    expect(renders).toBe(settled)
+  })
+
+  it('re-renders when the hit list actually changes', () => {
+    const raf = patchRaf()
+    const first = document.createElement('div')
+    const second = document.createElement('span')
+    let hit = [first]
+    const doc = { elementsFromPoint: () => [...hit] } as unknown as Document
+
+    const { result } = renderHook(() =>
+      useElementByPoint({ x: 1, y: 2, document: doc, multiple: true }),
+    )
+
+    act(() => { raf.flush() })
+    expect(result.current.element).toEqual([first])
+
+    hit = [second, first]
+    act(() => { raf.flush() })
+    expect(result.current.element).toEqual([second, first])
+  })
+})

--- a/packages/core/src/useElementByPoint/index.ts
+++ b/packages/core/src/useElementByPoint/index.ts
@@ -35,10 +35,20 @@ export const useElementByPoint: UseElementByPoint = options => {
 
   const cb = useCallback(() => {
     const { x: currentX, y: currentY } = getXY()
-    setElement(
+    const next = multiple
+      ? doc?.elementsFromPoint(currentX, currentY) ?? []
+      : doc?.elementFromPoint(currentX, currentY) ?? null
+    // elementsFromPoint allocates a fresh array on every call, so storing it
+    // as-is would re-render on every frame of the rAF loop even while the
+    // pointer sits still. The single-element branch needs no such check —
+    // elementFromPoint returns the same node and React bails out on its own.
+    setElement((prev: any) =>
       multiple
-        ? doc?.elementsFromPoint(currentX, currentY) ?? []
-        : doc?.elementFromPoint(currentX, currentY) ?? null,
+      && Array.isArray(prev)
+      && prev.length === next.length
+      && prev.every((el: Element, i: number) => el === next[i])
+        ? prev
+        : next,
     )
   }, [doc, multiple, getXY])
 


### PR DESCRIPTION
## Description

With `multiple: true`, `useElementByPoint` re-renders the consuming component on
every animation frame, even when the pointer hasn't moved and the elements under
it haven't changed.

`elementsFromPoint()` returns a freshly allocated array on each call, so the rAF
loop hands `setElement` a new reference every frame. React compares by identity,
sees a change, and re-renders — roughly 60 times a second, for as long as the
hook is active. The single-element path doesn't have this problem, since
`elementFromPoint()` returns the same node and React bails out on its own.

The fix compares the hit list by contents and keeps the previous array when
nothing changed. I used the functional form of `setElement` so the comparison
sees the committed value without needing an extra ref.

## Type of Change
- [x] Bug fix
- [ ] New hook
- [ ] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation

No doc change — public API and return values are unchanged.

This hook had no spec file, so I added one. Three tests: the element is reported
for the single case, an unchanged hit list no longer re-renders (3 renders over 3
frames on `main`, 0 here), and a hit list that genuinely changes still updates —
that last one matters, since a comparison like this is exactly the kind of change
that can silently freeze state.
