### PR TITLE
fix(useOrientation): correct the inverted isBrowser guards in lockOrientation/unlockOrientation

### DIFF
--- a/packages/core/jest-setup.ts
+++ b/packages/core/jest-setup.ts
@@ -1,22 +1,25 @@
-// Initialize error array
-window.testErrors = []
-
-// Add global error listener
-window.addEventListener('error', (event: MyErrorEvent) => {
-  window.testErrors.push({
-    message: event.message,
-    filename: event.filename,
-    lineno: event.lineno,
-    colno: event.colno,
-    error: event.error,
-  })
-})
-
-// Jest configuration
-beforeEach(() => {
-  // Clear error array before each test
+// window is absent in node-environment suites (SSR specs)
+if (typeof window !== 'undefined') {
+  // Initialize error array
   window.testErrors = []
-})
+
+  // Add global error listener
+  window.addEventListener('error', (event: MyErrorEvent) => {
+    window.testErrors.push({
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+      error: event.error,
+    })
+  })
+
+  // Jest configuration
+  beforeEach(() => {
+    // Clear error array before each test
+    window.testErrors = []
+  })
+}
 
 expect.extend({
   toHaveErrorMatching(received: typeof window.testErrors, expectedError: string | RegExp) {

--- a/packages/core/src/useOrientation/index.spec.ts
+++ b/packages/core/src/useOrientation/index.spec.ts
@@ -75,4 +75,53 @@ describe('useOrientation', () => {
     expect(hook.result.current[0].type).toBe(void 0)
     expect(hook.result.current[0].angle).toBe(0)
   })
+
+  it('should lock orientation through screen.orientation.lock', () => {
+    const lockResult = Promise.resolve()
+    const lock = jest.fn().mockReturnValue(lockResult);
+    (window.screen.orientation as unknown) = {
+      type: 'landscape-primary',
+      angle: 0,
+      lock,
+      unlock: jest.fn(),
+    }
+
+    const hook = getHook()
+
+    expect(hook.result.current[1]('portrait')).toBe(lockResult)
+    expect(lock).toHaveBeenCalledWith('portrait')
+  })
+
+  it('should unlock orientation through screen.orientation.unlock', () => {
+    const unlock = jest.fn();
+    (window.screen.orientation as unknown) = {
+      type: 'landscape-primary',
+      angle: 0,
+      lock: jest.fn(),
+      unlock,
+    }
+
+    const hook = getHook()
+    hook.result.current[2]()
+
+    expect(unlock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reject the lock when screen.orientation is not available', async () => {
+    delete (window.screen as { orientation?: unknown }).orientation
+
+    const hook = getHook()
+
+    await expect(hook.result.current[1]('portrait')).rejects.toThrow(
+      'Not supported',
+    )
+  })
+
+  it('should not throw when unlocking without screen.orientation', () => {
+    delete (window.screen as { orientation?: unknown }).orientation
+
+    const hook = getHook()
+
+    expect(hook.result.current[2]()).toBeUndefined()
+  })
 })

--- a/packages/core/src/useOrientation/index.ssr.spec.tsx
+++ b/packages/core/src/useOrientation/index.ssr.spec.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+
+import ReactDOMServer from 'react-dom/server'
+import type { UseOrientationLockType } from './interface'
+import { useOrientation } from '.'
+
+describe('useOrientation SSR', () => {
+  it('should not touch window when locking or unlocking on the server', () => {
+    let lockOrientation: ((type: UseOrientationLockType) => any) | undefined
+    let unlockOrientation: (() => void) | undefined
+
+    function TestComponent() {
+      const [state, lock, unlock] = useOrientation()
+      lockOrientation = lock
+      unlockOrientation = unlock
+      return <span>{`${state.type}:${state.angle}`}</span>
+    }
+
+    const markup = ReactDOMServer.renderToString(<TestComponent />)
+
+    // Guard against a vacuous pass: the render must have happened and
+    // handed the real functions out before we exercise them.
+    expect(markup).toBe('<span>landscape-primary:0</span>')
+    expect(lockOrientation).toBeDefined()
+    expect(unlockOrientation).toBeDefined()
+
+    expect(() => lockOrientation!('portrait')).not.toThrow()
+    expect(lockOrientation!('portrait')).toBeUndefined()
+    expect(() => unlockOrientation!()).not.toThrow()
+  })
+})

--- a/packages/core/src/useOrientation/index.ts
+++ b/packages/core/src/useOrientation/index.ts
@@ -45,7 +45,7 @@ export const useOrientation: UseOrientation = (
   }, [])
 
   const lockOrientation = (type: UseOrientationLockType) => {
-    if (isBrowser) {
+    if (!isBrowser) {
       return
     }
     if (!(window && 'screen' in window && 'orientation' in window.screen)) {
@@ -55,7 +55,7 @@ export const useOrientation: UseOrientation = (
   }
 
   const unlockOrientation = () => {
-    if (isBrowser) {
+    if (!isBrowser) {
       return
     }
     if (!(window && 'screen' in window && 'orientation' in window.screen)) {


### PR DESCRIPTION
## Description

Follow-up to the note in #211: the `isBrowser` guards in `useOrientation`'s
`lockOrientation` / `unlockOrientation` are inverted:

```ts
if (isBrowser) {
  return
}
```

So both functions no-op in every browser — `screen.orientation.lock()` /
`unlock()` are never called — and fall through on the server, where the bare
`window` reference on the next line throws `ReferenceError: window is not
defined`. Neither path had test coverage.

Fix: `if (!isBrowser) return`. The unsupported-browser rejection and the
promise passthrough from `lock()` are unchanged — they were just unreachable
before.

One test-infra change: `jest-setup.ts` touched `window` unconditionally, so a
`@jest-environment node` suite couldn't run at all. The setup is now guarded
with `typeof window !== 'undefined'`; jsdom suites are unaffected.

## Type of Change

- [x] Bug fix
- [ ] New hook
- [ ] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation

No doc change — the docs already describe the fixed behaviour.

Five tests added, four of them fail on `main`:

- `lockOrientation` calls `screen.orientation.lock(type)` and returns its promise
- `unlockOrientation` calls `screen.orientation.unlock()`
- `lockOrientation` rejects with `Not supported` when `screen.orientation` is absent
- an SSR spec (`@jest-environment node`, `renderToString`) — fails on `main` with the `ReferenceError`

The fifth (`unlockOrientation` doesn't throw without `screen.orientation`) also
passes on `main`; it covers the support branch this fix makes reachable.

Full suite passes (312 tests). Also verified against the built `dist/index.mjs`
in plain Node: render + `lock()`/`unlock()` are no-ops, no throw.

Not covered: browsers where `screen.orientation` exists but `lock` doesn't
(iOS Safari) still throw a sync `TypeError` rather than reject — same support
check as before.

#211 touches the same file, so whichever lands second may need a trivial rebase.
