### PR TITLE
docs: fix the LLM-friendly documentation link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Add the following to your configuration:
 
 ## Documentation
 
-📖 [Full Documentation](https://reactuse.com) | 📖 [LLM-friendly Documentation](https://reactuse.com/llm.txt) | 💬 [Discord](https://discord.gg/VEMFdByJ) | 🐛 [Issues](https://github.com/childrentime/reactuse/issues)
+📖 [Full Documentation](https://reactuse.com) | 📖 [LLM-friendly Documentation](https://reactuse.com/llms.txt) | 💬 [Discord](https://discord.gg/VEMFdByJ) | 🐛 [Issues](https://github.com/childrentime/reactuse/issues)
 
 ---
 


### PR DESCRIPTION
README line 147 links the LLM-friendly docs as `https://reactuse.com/llm.txt`, which returns 404. The site serves it at `https://reactuse.com/llms.txt`, which returns 200 — and `llms.txt` is the conventional filename, which `docs/ai-visibility-geo.md` itself uses throughout when explaining the convention.

One character, but it is in the header row of the README, so it is one of the first links anyone follows.

I checked the rest of the markdown while I was there. Nothing else needs fixing: `github.com/you/project` is a placeholder, and two external blog posts (`evilmartians.com/chronicles/optimizing-content-for-ai-discovery`, `searchviu.com/en/how-llms-actually-use-schema-markup/`) 404 but they are third-party articles inside `docs/ai-visibility-geo.md`, so repointing them is your editorial call rather than a link fix. The `stargazers` URL only appears dead to a scripted request — the repo has 1,049 stars and the page loads in a browser.

AI disclosure, per `.claude/ai-policy.md`: this was found and prepared with Claude Opus 5 in Claude Code, which swept the repo links; I verified both URLs by request before submitting. Per the same policy, review replies here will be mine rather than an agent's.