### PR TITLE
fix(useCycleList): derive the next index from the current state

### DIFF
--- a/packages/core/src/useCycleList/index.spec.ts
+++ b/packages/core/src/useCycleList/index.spec.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react'
+import { useCycleList } from '.'
+
+function setUp<T>(list: T[], initial?: number) {
+  return renderHook(() => useCycleList(list, initial))
+}
+
+it('should init with the first item', () => {
+  const { result } = setUp(['a', 'b', 'c'])
+  expect(result.current[0]).toEqual('a')
+})
+
+it('should init at the given index', () => {
+  const { result } = setUp(['a', 'b', 'c'], 1)
+  expect(result.current[0]).toEqual('b')
+})
+
+it('should cycle forward and wrap around', () => {
+  const { result } = setUp(['a', 'b', 'c'])
+  const next = () => act(() => result.current[1]())
+
+  next()
+  expect(result.current[0]).toEqual('b')
+  next()
+  expect(result.current[0]).toEqual('c')
+  next()
+  expect(result.current[0]).toEqual('a')
+})
+
+it('should cycle backward and wrap around', () => {
+  const { result } = setUp(['a', 'b', 'c'])
+  act(() => result.current[2]())
+  expect(result.current[0]).toEqual('c')
+})
+
+it('should accept a step', () => {
+  const { result } = setUp(['a', 'b', 'c', 'd'])
+  act(() => result.current[1](2))
+  expect(result.current[0]).toEqual('c')
+  act(() => result.current[2](3))
+  expect(result.current[0]).toEqual('d')
+})
+
+// Both calls used to read the same `index` from the closure, so the second
+// overwrote the first instead of advancing from it.
+it('should apply every call when several land in one batch', () => {
+  const { result } = setUp(['a', 'b', 'c'])
+  act(() => {
+    result.current[1]()
+    result.current[1]()
+  })
+  expect(result.current[0]).toEqual('c')
+})
+
+it('should cancel out a next and a prev in the same batch', () => {
+  const { result } = setUp(['a', 'b', 'c'], 1)
+  act(() => {
+    result.current[1]()
+    result.current[2]()
+  })
+  expect(result.current[0]).toEqual('b')
+})
+
+// `% 0` is NaN, which used to be stored as the index. Reading the value back on
+// an empty list cannot show that - `list[NaN]` and `list[0]` are both undefined
+// - so the list grows afterwards, where a NaN index stays undefined forever.
+it('should keep a usable index when cycling an empty list', () => {
+  const { result, rerender } = renderHook(
+    (list: string[]) => useCycleList(list),
+    { initialProps: [] as string[] },
+  )
+
+  act(() => result.current[1]())
+  expect(result.current[0]).toBeUndefined()
+
+  rerender(['a', 'b', 'c'])
+  expect(result.current[0]).toEqual('a')
+})

--- a/packages/core/src/useCycleList/index.ts
+++ b/packages/core/src/useCycleList/index.ts
@@ -8,9 +8,13 @@ export const useCycleList: UseCycleList = <T> (
   const [index, setIndex] = useState(i)
 
   const set = (i: number) => {
-    const length = list.length
-    const nextIndex = (((index + i) % length) + length) % length
-    setIndex(nextIndex)
+    setIndex(current => {
+      const length = list.length
+      // An empty list has no index to move to, and `% 0` is NaN.
+      if (length === 0)
+        return current
+      return (((current + i) % length) + length) % length
+    })
   }
 
   const next = (i = 1) => {


### PR DESCRIPTION
`useCycleList`'s `set` read `index` from the render closure:

```ts
const set = (i: number) => {
  const length = list.length
  const nextIndex = (((index + i) % length) + length) % length
  setIndex(nextIndex)
}
```

So two calls in the same batch both computed from the same `index` and the second overwrote the first. Calling `next()` twice in one handler advanced one step:

```ts
act(() => {
  next()
  next()
})
// 'b', where 'c' was expected
```

The updater form makes each call build on the previous one. Same for a `next()` and `prev()` that should cancel out.

Second, smaller thing in the same function: an empty list made `length` zero, so `(index + i) % 0` is `NaN` and that got stored as the index. Nothing recovers from it — if the list later fills in, `list[NaN]` is still `undefined`. It now leaves the index alone when there is nothing to cycle.

Added `src/useCycleList/index.spec.ts`, which the hook did not have. Three of its eight cases fail on `main` and pass here; the other five cover the behaviour I did not want to change (init, wrap-around both ways, and the step argument).

One note on the empty-list test: asserting the value on an empty list proves nothing, since `list[NaN]` and `list[0]` are both `undefined`. It rerenders with a filled list afterwards, which is where a `NaN` index is visible.

`pnpm lint`, `pnpm typecheck`, and `pnpm test` (386 tests, 67 suites) are green. No public API or type change.

AI disclosure per `.claude/ai-policy.md`: I found and wrote this with Claude Code (Claude Opus 5), and ran everything above locally. Per rule 4 of that policy, @rawsun007 will answer any review comments himself.
