### PR TITLE
fix(useIdle): cancel the timers on unmount

### DIFF
--- a/packages/core/src/useIdle/index.spec.ts
+++ b/packages/core/src/useIdle/index.spec.ts
@@ -1,0 +1,63 @@
+import { act, fireEvent, renderHook } from '@testing-library/react'
+import { useIdle } from '.'
+
+jest.useFakeTimers()
+
+it('should start from the initial state', () => {
+  expect(renderHook(() => useIdle(1000)).result.current).toBe(false)
+  expect(renderHook(() => useIdle(1000, true)).result.current).toBe(true)
+})
+
+it('should go idle once ms has passed', () => {
+  const { result } = renderHook(() => useIdle(1000))
+
+  act(() => {
+    jest.advanceTimersByTime(999)
+  })
+  expect(result.current).toBe(false)
+
+  act(() => {
+    jest.advanceTimersByTime(2)
+  })
+  expect(result.current).toBe(true)
+})
+
+it('should leave idle on activity and restart the countdown', () => {
+  const { result } = renderHook(() => useIdle(1000))
+
+  act(() => {
+    jest.advanceTimersByTime(1001)
+  })
+  expect(result.current).toBe(true)
+
+  act(() => {
+    fireEvent.keyDown(window)
+    jest.advanceTimersByTime(51)
+  })
+  expect(result.current).toBe(false)
+
+  act(() => {
+    jest.advanceTimersByTime(1001)
+  })
+  expect(result.current).toBe(true)
+})
+
+// The idle timer runs for `ms` and the throttled listener keeps one of its own,
+// so an uncancelled pair outlives the component by up to that long.
+it('should leave no timer behind on unmount', () => {
+  const { unmount } = renderHook(() => useIdle(60000))
+  expect(jest.getTimerCount()).toBeGreaterThan(0)
+
+  unmount()
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+it('should leave no timer behind after activity then unmount', () => {
+  const { unmount } = renderHook(() => useIdle(60000))
+
+  act(() => {
+    fireEvent.mouseMove(window)
+  })
+  unmount()
+  expect(jest.getTimerCount()).toBe(0)
+})

--- a/packages/core/src/useIdle/index.ts
+++ b/packages/core/src/useIdle/index.ts
@@ -54,6 +54,11 @@ export const useIdle: UseIdle = (
 
     return () => {
       mounted = false
+      // The idle timer runs for `ms` (a minute by default) and the throttled
+      // handler holds one of its own, so both outlive the component unless they
+      // are cancelled here.
+      clearTimeout(timeout)
+      onEvent.cancel()
 
       for (let i = 0; i < events.length; i++) {
         off(window, events[i], onEvent)


### PR DESCRIPTION
`useIdle`'s cleanup removes the listeners but leaves both timers running:

- the idle countdown, `setTimeout(() => set(true), ms)` — `ms` is a minute by default;
- the throttled `onEvent`, which holds its own 50ms timer.

`mounted` stops the state update, so nothing warns. The timers just keep the effect's closure alive until they fire.

```ts
const { unmount } = renderHook(() => useIdle(60000))
unmount()
jest.getTimerCount()   // 1 before this change, 0 after
```

Added `src/useIdle/index.spec.ts`, which the hook did not have. Two of the five cases fail on `main`; the other three pin behaviour that must not change — the initial state, going idle once `ms` elapses, and activity clearing idle and restarting the countdown.

`pnpm lint`, `pnpm typecheck` and `pnpm test` (391 tests, 68 suites) are green. No API or type change.

While I was looking I also noticed the export is `useWindowsFocus` with a stray `s` while the directory, the registry and the docs title all say `useWindowFocus` — but #205 already renames it as part of the v7 consistency pass, so I left it alone rather than duplicate your work. Nothing here touches the files in that PR.

AI disclosure per `.claude/ai-policy.md`: found and written with Claude Code (Claude Opus 5), and I ran everything above locally. Per rule 4, @rawsun007 will answer any review comments himself.
