### PR TITLE
fix(useKeyModifier): detach the listeners and follow a changed modifier

### DIFF
--- a/packages/core/src/useKeyModifier/index.spec.ts
+++ b/packages/core/src/useKeyModifier/index.spec.ts
@@ -1,0 +1,123 @@
+import { act, renderHook } from '@testing-library/react'
+import { useKeyModifier } from '.'
+import type { KeyModifier } from './interface'
+
+function press(event: string, held: KeyModifier[]) {
+  const evt = new Event(event) as any
+  evt.getModifierState = (key: string) => held.includes(key as KeyModifier)
+  act(() => {
+    document.dispatchEvent(evt)
+  })
+}
+
+it('should start from the initial value', () => {
+  const { result } = renderHook(() => useKeyModifier('Shift'))
+  expect(result.current).toBe(false)
+
+  const withInitial = renderHook(() => useKeyModifier('Shift', { initial: true }))
+  expect(withInitial.result.current).toBe(true)
+})
+
+it('should follow the modifier as it is held and released', () => {
+  const { result } = renderHook(() => useKeyModifier('Shift'))
+
+  press('keydown', ['Shift'])
+  expect(result.current).toBe(true)
+
+  press('keyup', [])
+  expect(result.current).toBe(false)
+})
+
+it('should only listen to the events it was given', () => {
+  const { result } = renderHook(() => useKeyModifier('Shift', { events: ['keydown'] }))
+
+  press('mousedown', ['Shift'])
+  expect(result.current).toBe(false)
+
+  press('keydown', ['Shift'])
+  expect(result.current).toBe(true)
+})
+
+// The listeners were registered through `useMount`, which discards the callback's
+// return value, and the cleanup passed a newly built arrow function to
+// `removeEventListener`, which matches by reference. So neither route detached
+// anything and every mount left four more listeners on `document`.
+it('should detach its listeners on unmount', () => {
+  const add = jest.spyOn(document, 'addEventListener')
+  const remove = jest.spyOn(document, 'removeEventListener')
+
+  try {
+    const { unmount } = renderHook(() => useKeyModifier('Shift'))
+    const added = add.mock.calls.filter(([, fn]) => typeof fn === 'function')
+    expect(added).toHaveLength(4)
+
+    unmount()
+
+    // Same event names and the same function references, or the listener stays.
+    const removed = remove.mock.calls.filter(([, fn]) => typeof fn === 'function')
+    expect(removed.map(([name]) => name).sort()).toEqual(
+      added.map(([name]) => name).sort(),
+    )
+    added.forEach(([, fn]) => {
+      expect(removed.some(([, off]) => off === fn)).toBe(true)
+    })
+  }
+  finally {
+    add.mockRestore()
+    remove.mockRestore()
+  }
+})
+
+// A stale listener is not just a leak: it still calls `setState` on an unmounted
+// component every time the key is pressed.
+it('should stop reporting after unmount', () => {
+  const { result, unmount } = renderHook(() => useKeyModifier('Shift'))
+
+  press('keydown', ['Shift'])
+  expect(result.current).toBe(true)
+
+  unmount()
+  const seen: string[] = []
+  const evt = new Event('keydown') as any
+  evt.getModifierState = (key: string) => {
+    seen.push(key)
+    return true
+  }
+  act(() => {
+    document.dispatchEvent(evt)
+  })
+
+  expect(seen).toEqual([])
+})
+
+// The handler closed over the mount-time `modifier`, and `useMount`'s empty
+// dependency list never re-registered it, so the argument was frozen for the
+// lifetime of the component.
+it('should follow a changed modifier', () => {
+  const { result, rerender } = renderHook(
+    (modifier: KeyModifier) => useKeyModifier(modifier),
+    { initialProps: 'Shift' as KeyModifier },
+  )
+
+  press('keydown', ['Control'])
+  expect(result.current).toBe(false)
+
+  rerender('Control')
+  press('keydown', ['Control'])
+  expect(result.current).toBe(true)
+})
+
+it('should not re-register when an inline events array is passed again', () => {
+  const add = jest.spyOn(document, 'addEventListener')
+
+  try {
+    const { rerender } = renderHook(() => useKeyModifier('Shift', { events: ['keydown'] }))
+    const first = add.mock.calls.length
+
+    rerender()
+    expect(add.mock.calls.length).toBe(first)
+  }
+  finally {
+    add.mockRestore()
+  }
+})

--- a/packages/core/src/useKeyModifier/index.ts
+++ b/packages/core/src/useKeyModifier/index.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useMount } from '../useMount'
+import { useDeepCompareEffect } from '../useDeepCompareEffect'
 import { off, on } from '../utils/browser'
 import { defaultOptions } from '../utils/defaults'
 import type { KeyModifier, UseKeyModifier, UseModifierOptions } from './interface'
@@ -19,25 +19,24 @@ export const useKeyModifier: UseKeyModifier = (
 
   const [state, setState] = useState<boolean>(initial)
 
-  useMount(() => {
-    events.forEach(listenEvent => {
-      on(document, listenEvent, (evt: KeyboardEvent) => {
-        if (typeof evt.getModifierState === 'function') {
-          setState(evt.getModifierState(modifier))
-        }
-      })
-    })
+  // Deep compare so an inline `events` array does not re-register on every
+  // render, while a changed `modifier` or event list does.
+  useDeepCompareEffect(() => {
+    // One reference reaches both calls: `removeEventListener` matches on the
+    // callback identity, so a freshly built arrow function detaches nothing.
+    const handler = (evt: Event) => {
+      const event = evt as KeyboardEvent
+      if (typeof event.getModifierState === 'function') {
+        setState(event.getModifierState(modifier))
+      }
+    }
+
+    events.forEach(listenEvent => on(document, listenEvent, handler))
 
     return () => {
-      events.forEach(listenerEvent => {
-        off(document, listenerEvent, (evt: KeyboardEvent) => {
-          if (typeof evt.getModifierState === 'function') {
-            setState(evt.getModifierState(modifier))
-          }
-        })
-      })
+      events.forEach(listenEvent => off(document, listenEvent, handler))
     }
-  })
+  }, [modifier, events])
 
   return state
 }


### PR DESCRIPTION
## Description

`useKeyModifier` never detached its `document` listeners, and its `modifier` argument was frozen at mount.

Two separate reasons the cleanup did nothing. The listeners are registered through `useMount`, which calls `fn?.()` and discards the return value, so the cleanup the callback built was never reachable - `useMount`'s own doc page states that it "does not support a cleanup return value". And even called directly it would have detached nothing, because it passed a freshly built arrow function to `removeEventListener`, which matches on the callback reference.

So each mount added four more listeners to `document`, and each stale one still called `setState` on an unmounted component on every keypress or click. The docs demo mounts six instances of the hook, so a mount cycle of that page leaks 24.

The empty dependency list froze the arguments as well: the handler closed over the mount-time `modifier`, so going from `useKeyModifier('Shift')` to `useKeyModifier('Control')` kept reporting Shift. Same for `events`.

Registered in a `useDeepCompareEffect` keyed on `[modifier, events]` now, with the handler hoisted so one reference reaches both `on` and `off`. That is the shape `useEventListener` already uses in this package, including its comment about `removeEventListener` matching by reference. The deep compare is what keeps an inline `events` array from re-registering every render.

`useKeyModifier` had no spec, so this adds one. Three of its seven cases fail against main - listener detach, no reporting after unmount, and following a changed modifier - and the other four pin behaviour that must not change.

Verification on this machine: `pnpm test` 398 pass across 69 suites, `pnpm typecheck` and `pnpm lint` clean. Reverting only `useKeyModifier/index.ts` and keeping the spec fails exactly those three cases.

I did not touch `useMount` itself. Its behaviour is documented and other hooks may rely on it, so the fix stays inside the hook that misused it. Worth saying that `useMousePressed` and `useDoubleClick` have related defects I found while reading, but they are separate changes and I would rather not bundle them.

## Type of Change
- [x] Bug fix
- [ ] New hook
- [ ] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation

The documentation box is unticked because the docs already describe the behaviour this restores, so there was nothing to change.

Disclosure: the audit, the fix, the spec and this description were written by Claude Opus 5 running in Claude Code, on my machine and under my direction. I have not read the diff line by line myself yet.
