### PR TITLE
fix(useMousePressed): attach the touch and drag listeners to a ref target

### DIFF
--- a/packages/core/src/useMousePressed/index.spec.ts
+++ b/packages/core/src/useMousePressed/index.spec.ts
@@ -1,0 +1,141 @@
+import { act, render, renderHook } from '@testing-library/react'
+import { createElement, useRef } from 'react'
+import { useMousePressed } from '.'
+import type { UseMousePressedOptions } from './interface'
+
+const DRAG_EVENTS = ['dragstart', 'drop', 'dragend']
+const TOUCH_EVENTS = ['touchstart', 'touchend', 'touchcancel']
+
+// Renders the hook against a ref the way a component does, so the element is
+// assigned while committing, which is after render and before the effects. The
+// spies go on that one element rather than on HTMLElement.prototype, which would
+// also catch React's own delegated listeners on the container.
+function renderWithRef(options?: UseMousePressedOptions) {
+  let add: jest.SpyInstance | undefined
+  let remove: jest.SpyInstance | undefined
+
+  function Probe() {
+    const ref = useRef<HTMLDivElement | null>(null)
+    useMousePressed(ref, options)
+    return createElement('div', {
+      ref: (el: HTMLDivElement | null) => {
+        ref.current = el
+        if (el && !add) {
+          add = jest.spyOn(el, 'addEventListener')
+          remove = jest.spyOn(el, 'removeEventListener')
+        }
+      },
+    })
+  }
+
+  const rendered = render(createElement(Probe))
+  const calls = (spy?: jest.SpyInstance) => spy ? spy.mock.calls : []
+
+  return {
+    ...rendered,
+    added: () => calls(add).map(([name]) => name as string),
+    addCalls: () => calls(add),
+    removeCalls: () => calls(remove),
+    restore: () => {
+      add?.mockRestore()
+      remove?.mockRestore()
+    },
+  }
+}
+
+function setUpElement(options?: UseMousePressedOptions) {
+  const target = document.createElement('div')
+  const rendered = renderHook(() => useMousePressed(target, options))
+  const fire = (type: string) => act(() => {
+    target.dispatchEvent(new Event(type))
+  })
+  return { ...rendered, target, fire }
+}
+
+it('should start from the initial value', () => {
+  const { result } = setUpElement()
+  expect(result.current[0]).toBe(false)
+  expect(result.current[1]).toBeNull()
+
+  const withInitial = setUpElement({ initialValue: true })
+  expect(withInitial.result.current[0]).toBe(true)
+})
+
+it('should report a mouse press and its release', () => {
+  const { result, fire } = setUpElement()
+
+  fire('mousedown')
+  expect(result.current).toEqual([true, 'mouse'])
+
+  act(() => {
+    window.dispatchEvent(new Event('mouseup'))
+  })
+  expect(result.current).toEqual([false, null])
+})
+
+it('should report a touch press with its own source type', () => {
+  const { result, fire } = setUpElement()
+
+  fire('touchstart')
+  expect(result.current).toEqual([true, 'touch'])
+
+  fire('touchend')
+  expect(result.current).toEqual([false, null])
+})
+
+// The target was resolved during render, where a ref handed to a child is still
+// null, and the effect's dependency on the resolved element meant it never ran
+// again. So only `mousedown`, which goes through `useEventListener` and resolves
+// inside its own effect, was ever attached.
+it('should attach the touch and drag listeners to a ref target', () => {
+  const probe = renderWithRef()
+
+  try {
+    const added = probe.added()
+    TOUCH_EVENTS.forEach(name => expect(added).toContain(name))
+    DRAG_EVENTS.forEach(name => expect(added).toContain(name))
+  }
+  finally {
+    probe.restore()
+  }
+})
+
+it('should honour touch: false and drag: false for a ref target', () => {
+  const probe = renderWithRef({ touch: false, drag: false })
+
+  try {
+    const added = probe.added()
+    TOUCH_EVENTS.forEach(name => expect(added).not.toContain(name))
+    DRAG_EVENTS.forEach(name => expect(added).not.toContain(name))
+    expect(added).toContain('mousedown')
+  }
+  finally {
+    probe.restore()
+  }
+})
+
+// `onPressed` was curried, so `onPressed('mouse')` built a new function for the
+// add and another for the remove. removeEventListener matches on the callback
+// reference, so those two never came off.
+it('should detach every listener it attached on unmount', () => {
+  const probe = renderWithRef()
+
+  try {
+    const added = probe.addCalls().filter(([name]) =>
+      TOUCH_EVENTS.includes(name as string) || DRAG_EVENTS.includes(name as string),
+    )
+    expect(added.length).toBe(TOUCH_EVENTS.length + DRAG_EVENTS.length)
+
+    probe.unmount()
+
+    const removed = probe.removeCalls()
+    added.forEach(([name, fn]) => {
+      expect(
+        removed.some(([offName, offFn]) => offName === name && offFn === fn),
+      ).toBe(true)
+    })
+  }
+  finally {
+    probe.restore()
+  }
+})

--- a/packages/core/src/useMousePressed/index.ts
+++ b/packages/core/src/useMousePressed/index.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useEventListener } from '../useEventListener'
 import { defaultOptions } from '../utils/defaults'
 import { getTargetElement } from '../utils/domTarget'
+import { useStableTarget } from '../utils/useStableTarget'
 import type { UseMousePressed, UseMousePressedOptions, UseMousePressedSourceType } from './interface'
 
 const listenerOptions = { passive: true }
@@ -14,58 +15,61 @@ export const useMousePressed: UseMousePressed = (
 
   const [pressed, setPressed] = useState(initialValue)
   const [sourceType, setSourceType] = useState<UseMousePressedSourceType>(null)
-  const element = getTargetElement(target)
+  const { key: elementKey, ref: elementRef } = useStableTarget(target)
 
-  const onPressed = useCallback(
-    (srcType: UseMousePressedSourceType) => () => {
-      setPressed(true)
-      setSourceType(srcType)
-    },
-    [],
-  )
+  // One reference per handler: removeEventListener matches on the callback, so a
+  // curried `onPressed('mouse')` built a different function for the add and the
+  // remove and detached neither.
+  const onMousePressed = useCallback(() => {
+    setPressed(true)
+    setSourceType('mouse')
+  }, [])
+  const onTouchPressed = useCallback(() => {
+    setPressed(true)
+    setSourceType('touch')
+  }, [])
   const onReleased = useCallback(() => {
     setPressed(false)
     setSourceType(null)
   }, [])
 
-  useEventListener('mousedown', onPressed('mouse'), target, listenerOptions)
+  useEventListener('mousedown', onMousePressed, target, listenerOptions)
   useEventListener('mouseleave', onReleased, () => window, listenerOptions)
   useEventListener('mouseup', onReleased, () => window, listenerOptions)
 
   useEffect(() => {
+    // Resolved here rather than during render: a ref handed to a child is still
+    // null while rendering, and the effect would never run again to pick it up.
+    const element = getTargetElement(elementRef.current)
+    if (!element) {
+      return
+    }
+
     if (drag) {
-      element?.addEventListener(
-        'dragstart',
-        onPressed('mouse'),
-        listenerOptions,
-      )
-      element?.addEventListener('drop', onReleased, listenerOptions)
-      element?.addEventListener('dragend', onReleased, listenerOptions)
+      element.addEventListener('dragstart', onMousePressed, listenerOptions)
+      element.addEventListener('drop', onReleased, listenerOptions)
+      element.addEventListener('dragend', onReleased, listenerOptions)
     }
 
     if (touch) {
-      element?.addEventListener(
-        'touchstart',
-        onPressed('touch'),
-        listenerOptions,
-      )
-      element?.addEventListener('touchend', onReleased, listenerOptions)
-      element?.addEventListener('touchcancel', onReleased, listenerOptions)
+      element.addEventListener('touchstart', onTouchPressed, listenerOptions)
+      element.addEventListener('touchend', onReleased, listenerOptions)
+      element.addEventListener('touchcancel', onReleased, listenerOptions)
     }
 
     return () => {
       if (drag) {
-        element?.removeEventListener('dragstart', onPressed('mouse'))
-        element?.removeEventListener('drop', onReleased)
-        element?.removeEventListener('dragend', onReleased)
+        element.removeEventListener('dragstart', onMousePressed)
+        element.removeEventListener('drop', onReleased)
+        element.removeEventListener('dragend', onReleased)
       }
       if (touch) {
-        element?.removeEventListener('touchstart', onPressed('touch'))
-        element?.removeEventListener('touchend', onReleased)
-        element?.removeEventListener('touchcancel', onReleased)
+        element.removeEventListener('touchstart', onTouchPressed)
+        element.removeEventListener('touchend', onReleased)
+        element.removeEventListener('touchcancel', onReleased)
       }
     }
-  }, [drag, onPressed, onReleased, touch, element])
+  }, [drag, touch, elementKey, elementRef, onMousePressed, onTouchPressed, onReleased])
 
   return [pressed, sourceType] as const
 }


### PR DESCRIPTION
## Description

follow up to #224, which mentioned this as a separate change.

`useMousePressed` resolves its target during render (`const element = getTargetElement(target)`), and a ref handed to a child is still null then. the effect depends on that resolved element, so it never runs again to pick it up. with the usual `useRef(null)` pattern the documented `touch` and `drag` listeners are never attached at all. `mousedown` works, because it goes through `useEventListener`, which resolves inside its own effect and says so in a comment there.

resolved inside the effect now and keyed on `useStableTarget`, the same shape `useEventListener` uses.

second defect in the same block: `onPressed` was curried, so `onPressed('mouse')` built one function for the add and a different one for the remove. `removeEventListener` matches on the callback reference, so `dragstart` and `touchstart` were never detached. one stable handler each fixes it, and `onReleased` was already stable so the other four came off fine.

the hook had no spec, so this adds one. two of the six cases fail on main.

worth flagging how i measured it, because my first attempt was wrong: spying on `HTMLElement.prototype.addEventListener` also catches react 19's delegated listeners on the container, about 140 of them, which made the broken case look like it passed. the spec spies on the one element instead, via a callback ref so the spy is in place before the effects run.

verification: `pnpm test` 415 pass across 70 suites, typecheck and lint clean. reverting the whole file fails 2 of 6; restoring only the render-time resolution fails 3; restoring only the curried removal fails 1.

## Type of Change
- [x] Bug fix
- [ ] New hook
- [ ] Enhancement to existing hook
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation

the docs already describe the behaviour this restores, so there was nothing to change.

disclosure: written by Claude Opus 5 running in Claude Code, on my machine and under my direction. i have not read the diff line by line myself yet.
